### PR TITLE
ModelingCmdVariant impl macro

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Adding a new modeling command
+
+ - In `each_command.rs` add your new `struct MyNewCommand`
+ - In `def_enum.rs` add a new variant of `ModelingCmd` with your type, e.g. `MyNewCommand(MyNewCommand)`.
+ - If your command responds with data:
+   - In `output.rs`, add a `struct MyNewCommand` following the existing examples.
+   - Then scroll to the end of the file and `impl<'de> ModelingCmdOutput<'de> for MyNewCommand {}`
+ - In `impl_traits.rs` follow the examples to implement `ModelingCmdVariant<'de>` for your type `MyNewCommand` using either the `impl_variant_output!` or the `impl_variant_empty!` macro. If your command responds with data, use the former. If your command has no response, use the latter.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Adding a new modeling command
 
- - In `each_command.rs` add your new `struct MyNewCommand`
+ - In `each_command.rs` add your new `struct MyNewCommand` with one field for each parameter the command has.
  - In `def_enum.rs` add a new variant of `ModelingCmd` with your type, e.g. `MyNewCommand(MyNewCommand)`.
  - If your command responds with data:
    - In `output.rs`, add a `struct MyNewCommand` following the existing examples.
    - Then scroll to the end of the file and `impl<'de> ModelingCmdOutput<'de> for MyNewCommand {}`
+   - In `ok_response.rs` add your new type to the `build_enum!` macro.
  - In `impl_traits.rs` follow the examples to implement `ModelingCmdVariant<'de>` for your type `MyNewCommand` using either the `impl_variant_output!` or the `impl_variant_empty!` macro. If your command responds with data, use the former. If your command has no response, use the latter.

--- a/modeling-cmds/src/impl_traits.rs
+++ b/modeling-cmds/src/impl_traits.rs
@@ -5,11 +5,17 @@ impl<'de> ModelingCmdVariant<'de> for StartPath {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::StartPath(self)
     }
+    fn name() -> &'static str {
+        "StartPath"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for MovePathPen {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::MovePathPen(self)
+    }
+    fn name() -> &'static str {
+        "MovePathPen"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for ExtendPath {
@@ -17,11 +23,17 @@ impl<'de> ModelingCmdVariant<'de> for ExtendPath {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::ExtendPath(self)
     }
+    fn name() -> &'static str {
+        "ExtendPath"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for Extrude {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::Extrude(self)
+    }
+    fn name() -> &'static str {
+        "Extrude"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for ClosePath {
@@ -29,11 +41,17 @@ impl<'de> ModelingCmdVariant<'de> for ClosePath {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::ClosePath(self)
     }
+    fn name() -> &'static str {
+        "ClosePath"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for CameraDragStart {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::CameraDragStart(self)
+    }
+    fn name() -> &'static str {
+        "CameraDragStart"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for CameraDragMove {
@@ -41,11 +59,17 @@ impl<'de> ModelingCmdVariant<'de> for CameraDragMove {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::CameraDragMove(self)
     }
+    fn name() -> &'static str {
+        "CameraDragMove"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for CameraDragEnd {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::CameraDragEnd(self)
+    }
+    fn name() -> &'static str {
+        "CameraDragEnd"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for EnableSketchMode {
@@ -53,11 +77,17 @@ impl<'de> ModelingCmdVariant<'de> for EnableSketchMode {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::EnableSketchMode(self)
     }
+    fn name() -> &'static str {
+        "EnableSketchMode"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for DefaultCameraLookAt {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::DefaultCameraLookAt(self)
+    }
+    fn name() -> &'static str {
+        "DefaultCameraLookAt"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for DefaultCameraZoom {
@@ -65,11 +95,17 @@ impl<'de> ModelingCmdVariant<'de> for DefaultCameraZoom {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::DefaultCameraZoom(self)
     }
+    fn name() -> &'static str {
+        "DefaultCameraZoom"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for DefaultCameraEnableSketchMode {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::DefaultCameraEnableSketchMode(self)
+    }
+    fn name() -> &'static str {
+        "DefaultCameraEnableSketchMode"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for DefaultCameraDisableSketchMode {
@@ -77,11 +113,17 @@ impl<'de> ModelingCmdVariant<'de> for DefaultCameraDisableSketchMode {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::DefaultCameraDisableSketchMode(self)
     }
+    fn name() -> &'static str {
+        "DefaultCameraDisableSketchMode"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for DefaultCameraFocusOn {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::DefaultCameraFocusOn(self)
+    }
+    fn name() -> &'static str {
+        "DefaultCameraFocusOn"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for Export {
@@ -89,11 +131,17 @@ impl<'de> ModelingCmdVariant<'de> for Export {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::Export(self)
     }
+    fn name() -> &'static str {
+        "Export"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for EntityGetParentId {
     type Output = out::EntityGetParentId;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::EntityGetParentId(self)
+    }
+    fn name() -> &'static str {
+        "EntityGetParentId"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for EntityGetNumChildren {
@@ -101,11 +149,17 @@ impl<'de> ModelingCmdVariant<'de> for EntityGetNumChildren {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::EntityGetNumChildren(self)
     }
+    fn name() -> &'static str {
+        "EntityGetNumChildren"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for EntityGetChildUuid {
     type Output = out::EntityGetChildUuid;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::EntityGetChildUuid(self)
+    }
+    fn name() -> &'static str {
+        "EntityGetChildUuid"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for EntityGetAllChildUuids {
@@ -113,11 +167,17 @@ impl<'de> ModelingCmdVariant<'de> for EntityGetAllChildUuids {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::EntityGetAllChildUuids(self)
     }
+    fn name() -> &'static str {
+        "EntityGetAllChildUuids"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for EntityGetDistance {
     type Output = out::EntityGetDistance;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::EntityGetDistance(self)
+    }
+    fn name() -> &'static str {
+        "EntityGetDistance"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for EditModeEnter {
@@ -125,11 +185,17 @@ impl<'de> ModelingCmdVariant<'de> for EditModeEnter {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::EditModeEnter(self)
     }
+    fn name() -> &'static str {
+        "EditModeEnter"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for SelectWithPoint {
     type Output = out::SelectWithPoint;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::SelectWithPoint(self)
+    }
+    fn name() -> &'static str {
+        "SelectWithPoint"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for SelectAdd {
@@ -137,11 +203,17 @@ impl<'de> ModelingCmdVariant<'de> for SelectAdd {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::SelectAdd(self)
     }
+    fn name() -> &'static str {
+        "SelectAdd"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for SelectRemove {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::SelectRemove(self)
+    }
+    fn name() -> &'static str {
+        "SelectRemove"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for SelectReplace {
@@ -149,11 +221,17 @@ impl<'de> ModelingCmdVariant<'de> for SelectReplace {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::SelectReplace(self)
     }
+    fn name() -> &'static str {
+        "SelectReplace"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for HighlightSetEntity {
     type Output = out::HighlightSetEntity;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::HighlightSetEntity(self)
+    }
+    fn name() -> &'static str {
+        "HighlightSetEntity"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for HighlightSetEntities {
@@ -161,11 +239,17 @@ impl<'de> ModelingCmdVariant<'de> for HighlightSetEntities {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::HighlightSetEntities(self)
     }
+    fn name() -> &'static str {
+        "HighlightSetEntities"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for NewAnnotation {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::NewAnnotation(self)
+    }
+    fn name() -> &'static str {
+        "NewAnnotation"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for UpdateAnnotation {
@@ -173,11 +257,17 @@ impl<'de> ModelingCmdVariant<'de> for UpdateAnnotation {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::UpdateAnnotation(self)
     }
+    fn name() -> &'static str {
+        "UpdateAnnotation"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for ObjectVisible {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::ObjectVisible(self)
+    }
+    fn name() -> &'static str {
+        "ObjectVisible"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for ObjectBringToFront {
@@ -185,11 +275,17 @@ impl<'de> ModelingCmdVariant<'de> for ObjectBringToFront {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::ObjectBringToFront(self)
     }
+    fn name() -> &'static str {
+        "ObjectBringToFront"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for GetEntityType {
     type Output = out::GetEntityType;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::GetEntityType(self)
+    }
+    fn name() -> &'static str {
+        "GetEntityType"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for Solid2dAddHole {
@@ -197,11 +293,17 @@ impl<'de> ModelingCmdVariant<'de> for Solid2dAddHole {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::Solid2dAddHole(self)
     }
+    fn name() -> &'static str {
+        "Solid2dAddHole"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for Solid3dGetAllEdgeFaces {
     type Output = out::Solid3dGetAllEdgeFaces;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::Solid3dGetAllEdgeFaces(self)
+    }
+    fn name() -> &'static str {
+        "Solid3dGetAllEdgeFaces"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for Solid3dGetAllOppositeEdges {
@@ -209,11 +311,17 @@ impl<'de> ModelingCmdVariant<'de> for Solid3dGetAllOppositeEdges {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::Solid3dGetAllOppositeEdges(self)
     }
+    fn name() -> &'static str {
+        "Solid3dGetAllOppositeEdges"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for Solid3dGetOppositeEdge {
     type Output = out::Solid3dGetOppositeEdge;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::Solid3dGetOppositeEdge(self)
+    }
+    fn name() -> &'static str {
+        "Solid3dGetOppositeEdge"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for Solid3dGetNextAdjacentEdge {
@@ -221,11 +329,17 @@ impl<'de> ModelingCmdVariant<'de> for Solid3dGetNextAdjacentEdge {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::Solid3dGetNextAdjacentEdge(self)
     }
+    fn name() -> &'static str {
+        "Solid3dGetNextAdjacentEdge"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for Solid3dGetPrevAdjacentEdge {
     type Output = out::Solid3dGetPrevAdjacentEdge;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::Solid3dGetPrevAdjacentEdge(self)
+    }
+    fn name() -> &'static str {
+        "Solid3dGetPrevAdjacentEdge"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for SendObject {
@@ -233,11 +347,17 @@ impl<'de> ModelingCmdVariant<'de> for SendObject {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::SendObject(self)
     }
+    fn name() -> &'static str {
+        "SendObject"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for ObjectSetMaterialParamsPbr {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::ObjectSetMaterialParamsPbr(self)
+    }
+    fn name() -> &'static str {
+        "ObjectSetMaterialParamsPbr"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for EntitySetOpacity {
@@ -245,11 +365,17 @@ impl<'de> ModelingCmdVariant<'de> for EntitySetOpacity {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::EntitySetOpacity(self)
     }
+    fn name() -> &'static str {
+        "EntitySetOpacity"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for EntityFade {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::EntityFade(self)
+    }
+    fn name() -> &'static str {
+        "EntityFade"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for MakePlane {
@@ -257,11 +383,17 @@ impl<'de> ModelingCmdVariant<'de> for MakePlane {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::MakePlane(self)
     }
+    fn name() -> &'static str {
+        "MakePlane"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for PlaneSetColor {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::PlaneSetColor(self)
+    }
+    fn name() -> &'static str {
+        "PlaneSetColor"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for SetTool {
@@ -269,11 +401,17 @@ impl<'de> ModelingCmdVariant<'de> for SetTool {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::SetTool(self)
     }
+    fn name() -> &'static str {
+        "SetTool"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for MouseMove {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::MouseMove(self)
+    }
+    fn name() -> &'static str {
+        "MouseMove"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for MouseClick {
@@ -281,11 +419,17 @@ impl<'de> ModelingCmdVariant<'de> for MouseClick {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::MouseClick(self)
     }
+    fn name() -> &'static str {
+        "MouseClick"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for SketchModeEnable {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::SketchModeEnable(self)
+    }
+    fn name() -> &'static str {
+        "SketchModeEnable"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for SketchModeDisable {
@@ -293,11 +437,17 @@ impl<'de> ModelingCmdVariant<'de> for SketchModeDisable {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::SketchModeDisable(self)
     }
+    fn name() -> &'static str {
+        "SketchModeDisable"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for CurveGetType {
     type Output = out::CurveGetType;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::CurveGetType(self)
+    }
+    fn name() -> &'static str {
+        "CurveGetType"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for CurveGetControlPoints {
@@ -305,11 +455,17 @@ impl<'de> ModelingCmdVariant<'de> for CurveGetControlPoints {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::CurveGetControlPoints(self)
     }
+    fn name() -> &'static str {
+        "CurveGetControlPoints"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for TakeSnapshot {
     type Output = out::TakeSnapshot;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::TakeSnapshot(self)
+    }
+    fn name() -> &'static str {
+        "TakeSnapshot"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for MakeAxesGizmo {
@@ -317,11 +473,17 @@ impl<'de> ModelingCmdVariant<'de> for MakeAxesGizmo {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::MakeAxesGizmo(self)
     }
+    fn name() -> &'static str {
+        "MakeAxesGizmo"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for PathGetInfo {
     type Output = out::PathGetInfo;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::PathGetInfo(self)
+    }
+    fn name() -> &'static str {
+        "PathGetInfo"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for PathGetCurveUuidsForVertices {
@@ -329,11 +491,17 @@ impl<'de> ModelingCmdVariant<'de> for PathGetCurveUuidsForVertices {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::PathGetCurveUuidsForVertices(self)
     }
+    fn name() -> &'static str {
+        "PathGetCurveUuidsForVertices"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for PathGetVertexUuids {
     type Output = out::PathGetVertexUuids;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::PathGetVertexUuids(self)
+    }
+    fn name() -> &'static str {
+        "PathGetVertexUuids"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for HandleMouseDragStart {
@@ -341,11 +509,17 @@ impl<'de> ModelingCmdVariant<'de> for HandleMouseDragStart {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::HandleMouseDragStart(self)
     }
+    fn name() -> &'static str {
+        "HandleMouseDragStart"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for HandleMouseDragMove {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::HandleMouseDragMove(self)
+    }
+    fn name() -> &'static str {
+        "HandleMouseDragMove"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for HandleMouseDragEnd {
@@ -353,11 +527,17 @@ impl<'de> ModelingCmdVariant<'de> for HandleMouseDragEnd {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::HandleMouseDragEnd(self)
     }
+    fn name() -> &'static str {
+        "HandleMouseDragEnd"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for RemoveSceneObjects {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::RemoveSceneObjects(self)
+    }
+    fn name() -> &'static str {
+        "RemoveSceneObjects"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for CurveSetConstraint {
@@ -365,11 +545,17 @@ impl<'de> ModelingCmdVariant<'de> for CurveSetConstraint {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::CurveSetConstraint(self)
     }
+    fn name() -> &'static str {
+        "CurveSetConstraint"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for PlaneIntersectAndProject {
     type Output = out::PlaneIntersectAndProject;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::PlaneIntersectAndProject(self)
+    }
+    fn name() -> &'static str {
+        "PlaneIntersectAndProject"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for CurveGetEndPoints {
@@ -377,11 +563,17 @@ impl<'de> ModelingCmdVariant<'de> for CurveGetEndPoints {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::CurveGetEndPoints(self)
     }
+    fn name() -> &'static str {
+        "CurveGetEndPoints"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for ReconfigureStream {
     type Output = ();
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::ReconfigureStream(self)
+    }
+    fn name() -> &'static str {
+        "ReconfigureStream"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for ImportFiles {
@@ -389,11 +581,17 @@ impl<'de> ModelingCmdVariant<'de> for ImportFiles {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::ImportFiles(self)
     }
+    fn name() -> &'static str {
+        "ImportFiles"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for Mass {
     type Output = out::Mass;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::Mass(self)
+    }
+    fn name() -> &'static str {
+        "Mass"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for Volume {
@@ -401,11 +599,17 @@ impl<'de> ModelingCmdVariant<'de> for Volume {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::Volume(self)
     }
+    fn name() -> &'static str {
+        "Volume"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for Density {
     type Output = out::Density;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::Density(self)
+    }
+    fn name() -> &'static str {
+        "Density"
     }
 }
 impl<'de> ModelingCmdVariant<'de> for SurfaceArea {
@@ -413,16 +617,25 @@ impl<'de> ModelingCmdVariant<'de> for SurfaceArea {
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::SurfaceArea(self)
     }
+    fn name() -> &'static str {
+        "SurfaceArea"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for CenterOfMass {
     type Output = out::CenterOfMass;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::CenterOfMass(self)
     }
+    fn name() -> &'static str {
+        "CenterOfMass"
+    }
 }
 impl<'de> ModelingCmdVariant<'de> for GetSketchModePlane {
     type Output = out::GetSketchModePlane;
     fn into_enum(self) -> ModelingCmd {
         ModelingCmd::GetSketchModePlane(self)
+    }
+    fn name() -> &'static str {
+        "GetSketchModePlane"
     }
 }

--- a/modeling-cmds/src/impl_traits.rs
+++ b/modeling-cmds/src/impl_traits.rs
@@ -1,641 +1,101 @@
 use crate::{each_cmd::*, output as out, ModelingCmd, ModelingCmdVariant};
 
-impl<'de> ModelingCmdVariant<'de> for StartPath {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::StartPath(self)
-    }
-    fn name() -> &'static str {
-        "StartPath"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for MovePathPen {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::MovePathPen(self)
-    }
-    fn name() -> &'static str {
-        "MovePathPen"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for ExtendPath {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::ExtendPath(self)
-    }
-    fn name() -> &'static str {
-        "ExtendPath"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for Extrude {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::Extrude(self)
-    }
-    fn name() -> &'static str {
-        "Extrude"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for ClosePath {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::ClosePath(self)
-    }
-    fn name() -> &'static str {
-        "ClosePath"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for CameraDragStart {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::CameraDragStart(self)
-    }
-    fn name() -> &'static str {
-        "CameraDragStart"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for CameraDragMove {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::CameraDragMove(self)
-    }
-    fn name() -> &'static str {
-        "CameraDragMove"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for CameraDragEnd {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::CameraDragEnd(self)
-    }
-    fn name() -> &'static str {
-        "CameraDragEnd"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for EnableSketchMode {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::EnableSketchMode(self)
-    }
-    fn name() -> &'static str {
-        "EnableSketchMode"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for DefaultCameraLookAt {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::DefaultCameraLookAt(self)
-    }
-    fn name() -> &'static str {
-        "DefaultCameraLookAt"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for DefaultCameraZoom {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::DefaultCameraZoom(self)
-    }
-    fn name() -> &'static str {
-        "DefaultCameraZoom"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for DefaultCameraEnableSketchMode {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::DefaultCameraEnableSketchMode(self)
-    }
-    fn name() -> &'static str {
-        "DefaultCameraEnableSketchMode"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for DefaultCameraDisableSketchMode {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::DefaultCameraDisableSketchMode(self)
-    }
-    fn name() -> &'static str {
-        "DefaultCameraDisableSketchMode"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for DefaultCameraFocusOn {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::DefaultCameraFocusOn(self)
-    }
-    fn name() -> &'static str {
-        "DefaultCameraFocusOn"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for Export {
-    type Output = out::Export;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::Export(self)
-    }
-    fn name() -> &'static str {
-        "Export"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for EntityGetParentId {
-    type Output = out::EntityGetParentId;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::EntityGetParentId(self)
-    }
-    fn name() -> &'static str {
-        "EntityGetParentId"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for EntityGetNumChildren {
-    type Output = out::EntityGetNumChildren;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::EntityGetNumChildren(self)
-    }
-    fn name() -> &'static str {
-        "EntityGetNumChildren"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for EntityGetChildUuid {
-    type Output = out::EntityGetChildUuid;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::EntityGetChildUuid(self)
-    }
-    fn name() -> &'static str {
-        "EntityGetChildUuid"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for EntityGetAllChildUuids {
-    type Output = out::EntityGetAllChildUuids;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::EntityGetAllChildUuids(self)
-    }
-    fn name() -> &'static str {
-        "EntityGetAllChildUuids"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for EntityGetDistance {
-    type Output = out::EntityGetDistance;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::EntityGetDistance(self)
-    }
-    fn name() -> &'static str {
-        "EntityGetDistance"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for EditModeEnter {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::EditModeEnter(self)
-    }
-    fn name() -> &'static str {
-        "EditModeEnter"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for SelectWithPoint {
-    type Output = out::SelectWithPoint;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::SelectWithPoint(self)
-    }
-    fn name() -> &'static str {
-        "SelectWithPoint"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for SelectAdd {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::SelectAdd(self)
-    }
-    fn name() -> &'static str {
-        "SelectAdd"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for SelectRemove {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::SelectRemove(self)
-    }
-    fn name() -> &'static str {
-        "SelectRemove"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for SelectReplace {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::SelectReplace(self)
-    }
-    fn name() -> &'static str {
-        "SelectReplace"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for HighlightSetEntity {
-    type Output = out::HighlightSetEntity;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::HighlightSetEntity(self)
-    }
-    fn name() -> &'static str {
-        "HighlightSetEntity"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for HighlightSetEntities {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::HighlightSetEntities(self)
-    }
-    fn name() -> &'static str {
-        "HighlightSetEntities"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for NewAnnotation {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::NewAnnotation(self)
-    }
-    fn name() -> &'static str {
-        "NewAnnotation"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for UpdateAnnotation {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::UpdateAnnotation(self)
-    }
-    fn name() -> &'static str {
-        "UpdateAnnotation"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for ObjectVisible {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::ObjectVisible(self)
-    }
-    fn name() -> &'static str {
-        "ObjectVisible"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for ObjectBringToFront {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::ObjectBringToFront(self)
-    }
-    fn name() -> &'static str {
-        "ObjectBringToFront"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for GetEntityType {
-    type Output = out::GetEntityType;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::GetEntityType(self)
-    }
-    fn name() -> &'static str {
-        "GetEntityType"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for Solid2dAddHole {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::Solid2dAddHole(self)
-    }
-    fn name() -> &'static str {
-        "Solid2dAddHole"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for Solid3dGetAllEdgeFaces {
-    type Output = out::Solid3dGetAllEdgeFaces;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::Solid3dGetAllEdgeFaces(self)
-    }
-    fn name() -> &'static str {
-        "Solid3dGetAllEdgeFaces"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for Solid3dGetAllOppositeEdges {
-    type Output = out::Solid3dGetAllOppositeEdges;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::Solid3dGetAllOppositeEdges(self)
-    }
-    fn name() -> &'static str {
-        "Solid3dGetAllOppositeEdges"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for Solid3dGetOppositeEdge {
-    type Output = out::Solid3dGetOppositeEdge;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::Solid3dGetOppositeEdge(self)
-    }
-    fn name() -> &'static str {
-        "Solid3dGetOppositeEdge"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for Solid3dGetNextAdjacentEdge {
-    type Output = out::Solid3dGetNextAdjacentEdge;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::Solid3dGetNextAdjacentEdge(self)
-    }
-    fn name() -> &'static str {
-        "Solid3dGetNextAdjacentEdge"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for Solid3dGetPrevAdjacentEdge {
-    type Output = out::Solid3dGetPrevAdjacentEdge;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::Solid3dGetPrevAdjacentEdge(self)
-    }
-    fn name() -> &'static str {
-        "Solid3dGetPrevAdjacentEdge"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for SendObject {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::SendObject(self)
-    }
-    fn name() -> &'static str {
-        "SendObject"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for ObjectSetMaterialParamsPbr {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::ObjectSetMaterialParamsPbr(self)
-    }
-    fn name() -> &'static str {
-        "ObjectSetMaterialParamsPbr"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for EntitySetOpacity {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::EntitySetOpacity(self)
-    }
-    fn name() -> &'static str {
-        "EntitySetOpacity"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for EntityFade {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::EntityFade(self)
-    }
-    fn name() -> &'static str {
-        "EntityFade"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for MakePlane {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::MakePlane(self)
-    }
-    fn name() -> &'static str {
-        "MakePlane"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for PlaneSetColor {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::PlaneSetColor(self)
-    }
-    fn name() -> &'static str {
-        "PlaneSetColor"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for SetTool {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::SetTool(self)
-    }
-    fn name() -> &'static str {
-        "SetTool"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for MouseMove {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::MouseMove(self)
-    }
-    fn name() -> &'static str {
-        "MouseMove"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for MouseClick {
-    type Output = out::MouseClick;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::MouseClick(self)
-    }
-    fn name() -> &'static str {
-        "MouseClick"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for SketchModeEnable {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::SketchModeEnable(self)
-    }
-    fn name() -> &'static str {
-        "SketchModeEnable"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for SketchModeDisable {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::SketchModeDisable(self)
-    }
-    fn name() -> &'static str {
-        "SketchModeDisable"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for CurveGetType {
-    type Output = out::CurveGetType;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::CurveGetType(self)
-    }
-    fn name() -> &'static str {
-        "CurveGetType"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for CurveGetControlPoints {
-    type Output = out::CurveGetControlPoints;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::CurveGetControlPoints(self)
-    }
-    fn name() -> &'static str {
-        "CurveGetControlPoints"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for TakeSnapshot {
-    type Output = out::TakeSnapshot;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::TakeSnapshot(self)
-    }
-    fn name() -> &'static str {
-        "TakeSnapshot"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for MakeAxesGizmo {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::MakeAxesGizmo(self)
-    }
-    fn name() -> &'static str {
-        "MakeAxesGizmo"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for PathGetInfo {
-    type Output = out::PathGetInfo;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::PathGetInfo(self)
-    }
-    fn name() -> &'static str {
-        "PathGetInfo"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for PathGetCurveUuidsForVertices {
-    type Output = out::PathGetCurveUuidsForVertices;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::PathGetCurveUuidsForVertices(self)
-    }
-    fn name() -> &'static str {
-        "PathGetCurveUuidsForVertices"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for PathGetVertexUuids {
-    type Output = out::PathGetVertexUuids;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::PathGetVertexUuids(self)
-    }
-    fn name() -> &'static str {
-        "PathGetVertexUuids"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for HandleMouseDragStart {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::HandleMouseDragStart(self)
-    }
-    fn name() -> &'static str {
-        "HandleMouseDragStart"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for HandleMouseDragMove {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::HandleMouseDragMove(self)
-    }
-    fn name() -> &'static str {
-        "HandleMouseDragMove"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for HandleMouseDragEnd {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::HandleMouseDragEnd(self)
-    }
-    fn name() -> &'static str {
-        "HandleMouseDragEnd"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for RemoveSceneObjects {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::RemoveSceneObjects(self)
-    }
-    fn name() -> &'static str {
-        "RemoveSceneObjects"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for CurveSetConstraint {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::CurveSetConstraint(self)
-    }
-    fn name() -> &'static str {
-        "CurveSetConstraint"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for PlaneIntersectAndProject {
-    type Output = out::PlaneIntersectAndProject;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::PlaneIntersectAndProject(self)
-    }
-    fn name() -> &'static str {
-        "PlaneIntersectAndProject"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for CurveGetEndPoints {
-    type Output = out::CurveGetEndPoints;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::CurveGetEndPoints(self)
-    }
-    fn name() -> &'static str {
-        "CurveGetEndPoints"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for ReconfigureStream {
-    type Output = ();
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::ReconfigureStream(self)
-    }
-    fn name() -> &'static str {
-        "ReconfigureStream"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for ImportFiles {
-    type Output = out::ImportFiles;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::ImportFiles(self)
-    }
-    fn name() -> &'static str {
-        "ImportFiles"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for Mass {
-    type Output = out::Mass;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::Mass(self)
-    }
-    fn name() -> &'static str {
-        "Mass"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for Volume {
-    type Output = out::Volume;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::Volume(self)
-    }
-    fn name() -> &'static str {
-        "Volume"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for Density {
-    type Output = out::Density;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::Density(self)
-    }
-    fn name() -> &'static str {
-        "Density"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for SurfaceArea {
-    type Output = out::SurfaceArea;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::SurfaceArea(self)
-    }
-    fn name() -> &'static str {
-        "SurfaceArea"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for CenterOfMass {
-    type Output = out::CenterOfMass;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::CenterOfMass(self)
-    }
-    fn name() -> &'static str {
-        "CenterOfMass"
-    }
-}
-impl<'de> ModelingCmdVariant<'de> for GetSketchModePlane {
-    type Output = out::GetSketchModePlane;
-    fn into_enum(self) -> ModelingCmd {
-        ModelingCmd::GetSketchModePlane(self)
-    }
-    fn name() -> &'static str {
-        "GetSketchModePlane"
-    }
-}
+macro_rules! impl_variant_output {
+    ($struct:ident) => {
+        impl<'de> ModelingCmdVariant<'de> for $struct {
+            type Output = out::$struct;
+            fn into_enum(self) -> ModelingCmd {
+                ModelingCmd::$struct(self)
+            }
+            fn name() -> &'static str {
+                stringify!($struct)
+            }
+        }
+    };
+}
+
+macro_rules! impl_variant_empty {
+    ($struct:ident) => {
+        impl<'de> ModelingCmdVariant<'de> for $struct {
+            type Output = ();
+            fn into_enum(self) -> ModelingCmd {
+                ModelingCmd::$struct(self)
+            }
+            fn name() -> &'static str {
+                stringify!($struct)
+            }
+        }
+    };
+}
+
+impl_variant_empty!(StartPath);
+impl_variant_empty!(MovePathPen);
+impl_variant_empty!(ExtendPath);
+impl_variant_empty!(Extrude);
+impl_variant_empty!(ClosePath);
+impl_variant_empty!(CameraDragStart);
+impl_variant_empty!(CameraDragMove);
+impl_variant_empty!(CameraDragEnd);
+impl_variant_empty!(EnableSketchMode);
+impl_variant_empty!(DefaultCameraLookAt);
+impl_variant_empty!(DefaultCameraZoom);
+impl_variant_empty!(DefaultCameraEnableSketchMode);
+impl_variant_empty!(DefaultCameraDisableSketchMode);
+impl_variant_empty!(DefaultCameraFocusOn);
+impl_variant_output!(Export);
+impl_variant_output!(EntityGetParentId);
+impl_variant_output!(EntityGetNumChildren);
+impl_variant_output!(EntityGetChildUuid);
+impl_variant_output!(EntityGetAllChildUuids);
+impl_variant_output!(EntityGetDistance);
+impl_variant_empty!(EditModeEnter);
+impl_variant_output!(SelectWithPoint);
+impl_variant_empty!(SelectAdd);
+impl_variant_empty!(SelectRemove);
+impl_variant_empty!(SelectReplace);
+impl_variant_output!(HighlightSetEntity);
+impl_variant_empty!(HighlightSetEntities);
+impl_variant_empty!(NewAnnotation);
+impl_variant_empty!(UpdateAnnotation);
+impl_variant_empty!(ObjectVisible);
+impl_variant_empty!(ObjectBringToFront);
+impl_variant_output!(GetEntityType);
+impl_variant_empty!(Solid2dAddHole);
+impl_variant_output!(Solid3dGetAllEdgeFaces);
+impl_variant_output!(Solid3dGetAllOppositeEdges);
+impl_variant_output!(Solid3dGetOppositeEdge);
+impl_variant_output!(Solid3dGetNextAdjacentEdge);
+impl_variant_output!(Solid3dGetPrevAdjacentEdge);
+impl_variant_empty!(SendObject);
+impl_variant_empty!(ObjectSetMaterialParamsPbr);
+impl_variant_empty!(EntitySetOpacity);
+impl_variant_empty!(EntityFade);
+impl_variant_empty!(MakePlane);
+impl_variant_empty!(PlaneSetColor);
+impl_variant_empty!(SetTool);
+impl_variant_empty!(MouseMove);
+impl_variant_output!(MouseClick);
+impl_variant_empty!(SketchModeEnable);
+impl_variant_empty!(SketchModeDisable);
+impl_variant_output!(CurveGetType);
+impl_variant_output!(CurveGetControlPoints);
+impl_variant_output!(TakeSnapshot);
+impl_variant_empty!(MakeAxesGizmo);
+impl_variant_output!(PathGetInfo);
+impl_variant_output!(PathGetCurveUuidsForVertices);
+impl_variant_output!(PathGetVertexUuids);
+impl_variant_empty!(HandleMouseDragStart);
+impl_variant_empty!(HandleMouseDragMove);
+impl_variant_empty!(HandleMouseDragEnd);
+impl_variant_empty!(RemoveSceneObjects);
+impl_variant_empty!(CurveSetConstraint);
+impl_variant_empty!(ReconfigureStream);
+impl_variant_output!(PlaneIntersectAndProject);
+impl_variant_output!(CurveGetEndPoints);
+impl_variant_output!(ImportFiles);
+impl_variant_output!(Mass);
+impl_variant_output!(Volume);
+impl_variant_output!(Density);
+impl_variant_output!(SurfaceArea);
+impl_variant_output!(CenterOfMass);
+impl_variant_output!(GetSketchModePlane);

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::output;
 
+macro_rules! build_enum {
+    ($( $variant:ident ),* ) => {
 /// A successful response from a modeling command.
 /// This can be one of several types of responses, depending on the command.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -11,70 +13,47 @@ pub enum OkModelingCmdResponse {
     /// An empty response, used for any command that does not explicitly have a response
     /// defined here.
     Empty,
-    /// The response from the `Export` command.
-    /// When this is being performed over a websocket, this is sent as binary not JSON.
-    /// The binary data can be deserialized as `bincode` into a `Vec<ExportFile>`.
-    Export(output::Export),
-    /// The response from the `SelectWithPoint` command.
-    SelectWithPoint(output::SelectWithPoint),
-    /// The response from the `HighlightSetEntity` command.
-    HighlightSetEntity(output::HighlightSetEntity),
-    /// The response from the `EntityGetChildUuid` command.
-    EntityGetChildUuid(output::EntityGetChildUuid),
-    /// The response from the `EntityGetNumChildren` command.
-    EntityGetNumChildren(output::EntityGetNumChildren),
-    /// The response from the `EntityGetParentId` command.
-    EntityGetParentId(output::EntityGetParentId),
-    /// The response from the `EntityGetAllChildUuids` command.
-    EntityGetAllChildUuids(output::EntityGetAllChildUuids),
-    /// The response from the `SelectGet` command.
-    SelectGet(output::SelectGet),
-    /// The response from the `GetEntityType` command.
-    GetEntityType(output::GetEntityType),
-    /// The response from the `EntityGetDistance` command.
-    EntityGetDistance(output::EntityGetDistance),
-    /// The response from the `Solid3dGetAllEdgeFaces` command.
-    Solid3dGetAllEdgeFaces(output::Solid3dGetAllEdgeFaces),
-    /// The response from the `Solid3dGetAllOppositeEdges` command.
-    Solid3dGetAllOppositeEdges(output::Solid3dGetAllOppositeEdges),
-    /// The response from the `Solid3dGetOppositeEdge` command.
-    Solid3dGetOppositeEdge(output::Solid3dGetOppositeEdge),
-    /// The response from the `Solid3dGetPrevAdjacentEdge` command.
-    Solid3dGetPrevAdjacentEdge(output::Solid3dGetPrevAdjacentEdge),
-    /// The response from the `Solid3dGetNextAdjacentEdge` command.
-    Solid3dGetNextAdjacentEdge(output::Solid3dGetNextAdjacentEdge),
-    /// The response from the `MouseClick` command.
-    MouseClick(output::MouseClick),
-    /// The response from the `CurveGetType` command.
-    CurveGetType(output::CurveGetType),
-    /// The response from the `CurveGetControlPoints` command.
-    CurveGetControlPoints(output::CurveGetControlPoints),
-    /// The response from the `Take Snapshot` command.
-    TakeSnapshot(output::TakeSnapshot),
-    /// The response from the `Path Get Info` command.
-    PathGetInfo(output::PathGetInfo),
-    /// The response from the `Path Get Curve UUIDs for Vertices` command.
-    PathGetCurveUuidsForVertices(output::PathGetCurveUuidsForVertices),
-    /// The response from the `Path Get Vertex UUIDs` command.
-    PathGetVertexUuids(output::PathGetVertexUuids),
-    /// The response from the `PlaneIntersectAndProject` command.
-    PlaneIntersectAndProject(output::PlaneIntersectAndProject),
-    /// The response from the `CurveGetEndPoints` command.
-    CurveGetEndPoints(output::CurveGetEndPoints),
-    /// The response from the `ImportFiles` command.
-    ImportFiles(output::ImportFiles),
-    /// The response from the `Mass` command.
-    Mass(output::Mass),
-    /// The response from the `Volume` command.
-    Volume(output::Volume),
-    /// The response from the `Density` command.
-    Density(output::Density),
-    /// The response from the `SurfaceArea` command.
-    SurfaceArea(output::SurfaceArea),
-    /// The response from the `CenterOfMass` command.
-    CenterOfMass(output::CenterOfMass),
-    /// The response from the `GetSketchModePlane` command.
-    GetSketchModePlane(output::GetSketchModePlane),
+    $(
+        #[doc = "The response from the `"]
+        #[doc = stringify!($variant)]
+        #[doc = "` command."]
+        $variant(output::$variant),
+    )* }
+    };
+}
+
+build_enum! {
+    Export,
+    SelectWithPoint,
+    HighlightSetEntity,
+    EntityGetChildUuid,
+    EntityGetNumChildren,
+    EntityGetParentId,
+    EntityGetAllChildUuids,
+    SelectGet,
+    GetEntityType,
+    EntityGetDistance,
+    Solid3dGetAllEdgeFaces,
+    Solid3dGetAllOppositeEdges,
+    Solid3dGetOppositeEdge,
+    Solid3dGetPrevAdjacentEdge,
+    Solid3dGetNextAdjacentEdge,
+    MouseClick,
+    CurveGetType,
+    CurveGetControlPoints,
+    TakeSnapshot,
+    PathGetInfo,
+    PathGetCurveUuidsForVertices,
+    PathGetVertexUuids,
+    PlaneIntersectAndProject,
+    CurveGetEndPoints,
+    ImportFiles,
+    Mass,
+    Volume,
+    Density,
+    SurfaceArea,
+    CenterOfMass,
+    GetSketchModePlane
 }
 
 impl From<output::ImportFiles> for OkModelingCmdResponse {

--- a/modeling-cmds/src/traits.rs
+++ b/modeling-cmds/src/traits.rs
@@ -8,6 +8,8 @@ pub trait ModelingCmdVariant<'de>: Serialize {
     type Output: ModelingCmdOutput<'de>;
     /// Take this specific enum variant, and create the general enum.
     fn into_enum(self) -> ModelingCmd;
+    /// The command's name.
+    fn name() -> &'static str;
 }
 
 /// Anything that can be a ModelingCmd output.


### PR DESCRIPTION
- Add a new method to `ModelingCmdVariant` trait, `fn name()` which returns the command's name.
- Add a macro for implementing `ModelingCmdVariant`
- Add a macro for creating `OkModelingCmdResponse`
- Add CONTRIBUTING.md