### PR TITLE
execution-plan: Use snapshot tests for program memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +767,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1365,6 +1383,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d64600be34b2fcfc267740a243fa7744441bb4947a619ac4e5bb6507f35fbfc"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,6 +1517,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "image",
+ "insta",
  "kittycad",
  "kittycad-modeling-cmds",
  "kittycad-modeling-session",
@@ -2975,6 +3007,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "similar"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aeaf503862c419d66959f5d7ca015337d864e9c49485d771b732e2a20453597"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4017,6 +4055,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -4031,6 +4078,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4065,6 +4127,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -4074,6 +4142,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4089,6 +4163,12 @@ checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
@@ -4098,6 +4178,12 @@ name = "windows_i686_gnu"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4113,6 +4199,12 @@ checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
@@ -4125,6 +4217,12 @@ checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -4134,6 +4232,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/execution-plan/Cargo.toml
+++ b/execution-plan/Cargo.toml
@@ -9,6 +9,7 @@ description = "A DSL for composing KittyCAD API queries"
 
 [dependencies]
 bytes = "1.5"
+insta = "1.34.0"
 kittycad = { version = "0.2.44", features = ["requests"] }
 kittycad-modeling-cmds = { path = "../modeling-cmds" }
 kittycad-modeling-session = { path = "../modeling-session" }

--- a/execution-plan/src/snapshots/kittycad_execution_plan__tests__cube_memory_after.snap
+++ b/execution-plan/src/snapshots/kittycad_execution_plan__tests__cube_memory_after.snap
@@ -1,0 +1,37 @@
+---
+source: execution-plan/src/tests.rs
+expression: debug_dump_memory(&mem)
+---
+┌───────┬──────────┬──────────────────────────────────────┐
+│ index │ val_type │ value                                │
+├───────┼──────────┼──────────────────────────────────────┤
+│ 0     │ Uuid     │ 4cd175a3-e313-4c91-b624-368bea3c0483 │
+│ 2     │ Float    │ 40                                   │
+│ 3     │ Bool     │ true                                 │
+│ 4     │ String   │ png                                  │
+│ 6     │ Float    │ -20                                  │
+│ 7     │ Float    │ -20                                  │
+│ 8     │ Float    │ -20                                  │
+│ 9     │ String   │ line                                 │
+│ 10    │ Float    │ 20                                   │
+│ 11    │ Float    │ -20                                  │
+│ 12    │ Float    │ -20                                  │
+│ 13    │ Bool     │ false                                │
+│ 14    │ String   │ line                                 │
+│ 15    │ Float    │ 20                                   │
+│ 16    │ Float    │ 20                                   │
+│ 17    │ Float    │ -20                                  │
+│ 18    │ Bool     │ false                                │
+│ 19    │ String   │ line                                 │
+│ 20    │ Float    │ -20                                  │
+│ 21    │ Float    │ 20                                   │
+│ 22    │ Float    │ -20                                  │
+│ 23    │ Bool     │ false                                │
+│ 24    │ String   │ line                                 │
+│ 25    │ Float    │ -20                                  │
+│ 26    │ Float    │ -20                                  │
+│ 27    │ Float    │ -20                                  │
+│ 28    │ Bool     │ false                                │
+│ 99    │ String   │ TAKE_SNAPSHOT                        │
+│ 100   │ Bytes    │ length 129068                        │
+└───────┴──────────┴──────────────────────────────────────┘

--- a/execution-plan/src/snapshots/kittycad_execution_plan__tests__cube_memory_before.snap
+++ b/execution-plan/src/snapshots/kittycad_execution_plan__tests__cube_memory_before.snap
@@ -1,0 +1,35 @@
+---
+source: execution-plan/src/tests.rs
+expression: debug_dump_memory(&mem)
+---
+┌───────┬──────────┬──────────────────────────────────────┐
+│ index │ val_type │ value                                │
+├───────┼──────────┼──────────────────────────────────────┤
+│ 0     │ Uuid     │ 4cd175a3-e313-4c91-b624-368bea3c0483 │
+│ 2     │ Float    │ 40                                   │
+│ 3     │ Bool     │ true                                 │
+│ 4     │ String   │ png                                  │
+│ 6     │ Float    │ -20                                  │
+│ 7     │ Float    │ -20                                  │
+│ 8     │ Float    │ -20                                  │
+│ 9     │ String   │ line                                 │
+│ 10    │ Float    │ 20                                   │
+│ 11    │ Float    │ -20                                  │
+│ 12    │ Float    │ -20                                  │
+│ 13    │ Bool     │ false                                │
+│ 14    │ String   │ line                                 │
+│ 15    │ Float    │ 20                                   │
+│ 16    │ Float    │ 20                                   │
+│ 17    │ Float    │ -20                                  │
+│ 18    │ Bool     │ false                                │
+│ 19    │ String   │ line                                 │
+│ 20    │ Float    │ -20                                  │
+│ 21    │ Float    │ 20                                   │
+│ 22    │ Float    │ -20                                  │
+│ 23    │ Bool     │ false                                │
+│ 24    │ String   │ line                                 │
+│ 25    │ Float    │ -20                                  │
+│ 26    │ Float    │ -20                                  │
+│ 27    │ Float    │ -20                                  │
+│ 28    │ Bool     │ false                                │
+└───────┴──────────┴──────────────────────────────────────┘


### PR DESCRIPTION
This saves a "snapshot" of program memory (visualized as a table) into the repo. When you rerun the "draw cube via API" unit test, it'll compare the snapshot to what's on disk and fail if there's a change (like expectorate or twenty-twenty).

Use `cargo insta review` for reviewing changes and accepting/rejecting them.