### PR TITLE
execution-plan: Macro for implementing Value on structs

### DIFF
--- a/execution-plan/src/primitive.rs
+++ b/execution-plan/src/primitive.rs
@@ -1,4 +1,4 @@
-use kittycad_modeling_cmds::shared::Angle;
+use kittycad_modeling_cmds::{base64::Base64Data, shared::Angle};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -55,6 +55,12 @@ impl From<Angle> for Primitive {
 impl From<Vec<u8>> for Primitive {
     fn from(value: Vec<u8>) -> Self {
         Self::Bytes(value)
+    }
+}
+
+impl From<Base64Data> for Primitive {
+    fn from(value: Base64Data) -> Self {
+        Self::Bytes(value.into())
     }
 }
 
@@ -139,6 +145,14 @@ impl TryFrom<Primitive> for Vec<u8> {
                 actual: format!("{value:?}"),
             })
         }
+    }
+}
+
+impl TryFrom<Primitive> for Base64Data {
+    type Error = ExecutionError;
+
+    fn try_from(value: Primitive) -> Result<Self, Self::Error> {
+        Vec::<u8>::try_from(value).map(Base64Data::from)
     }
 }
 

--- a/execution-plan/src/primitive.rs
+++ b/execution-plan/src/primitive.rs
@@ -33,6 +33,12 @@ impl From<String> for Primitive {
     }
 }
 
+impl From<f32> for Primitive {
+    fn from(value: f32) -> Self {
+        Self::NumericValue(NumericPrimitive::Float(value as f64))
+    }
+}
+
 impl From<f64> for Primitive {
     fn from(value: f64) -> Self {
         Self::NumericValue(NumericPrimitive::Float(value))
@@ -113,6 +119,14 @@ impl TryFrom<Primitive> for f64 {
     }
 }
 
+impl TryFrom<Primitive> for f32 {
+    type Error = ExecutionError;
+
+    fn try_from(value: Primitive) -> Result<Self, Self::Error> {
+        f64::try_from(value).map(|x| x as f32)
+    }
+}
+
 impl TryFrom<Primitive> for Vec<u8> {
     type Error = ExecutionError;
 
@@ -143,7 +157,21 @@ impl TryFrom<Primitive> for bool {
     }
 }
 
-#[cfg(test)]
+impl TryFrom<Primitive> for usize {
+    type Error = ExecutionError;
+
+    fn try_from(value: Primitive) -> Result<Self, Self::Error> {
+        if let Primitive::NumericValue(NumericPrimitive::Integer(x)) = value {
+            Ok(x)
+        } else {
+            Err(ExecutionError::MemoryWrongType {
+                expected: "usize",
+                actual: format!("{value:?}"),
+            })
+        }
+    }
+}
+
 impl From<usize> for Primitive {
     fn from(value: usize) -> Self {
         Self::NumericValue(NumericPrimitive::Integer(value))

--- a/execution-plan/src/value/impls.rs
+++ b/execution-plan/src/value/impls.rs
@@ -5,9 +5,10 @@
 //! - This canonical ordering is the order of the struct's fields in its Rust source code definition.
 //! - Enums get laid out by first putting the variant as a string, then putting the variant's fields.
 use kittycad_modeling_cmds::{
+    base64::Base64Data,
     ok_response::OkModelingCmdResponse,
     output,
-    shared::{Angle, PathSegment, Point2d, Point3d},
+    shared::{Angle, PathSegment, Point2d, Point3d, Point4d},
 };
 use uuid::Uuid;
 
@@ -26,6 +27,9 @@ fn err() -> ExecutionError {
     ExecutionError::MemoryWrongSize
 }
 
+/// Macro to generate an `impl Value` for the given type `$subject`.
+/// The type `$subject` must be "primitive-ish",
+/// i.e. something that can be converted Into a Primitive and TryFrom a primitive
 macro_rules! impl_value_on_primitive_ish {
     ($subject:ident) => {
         impl Value for $subject {
@@ -52,6 +56,7 @@ type VecU8 = Vec<u8>;
 impl_value_on_primitive_ish!(VecU8);
 impl_value_on_primitive_ish!(Angle);
 impl_value_on_primitive_ish!(usize);
+impl_value_on_primitive_ish!(Base64Data);
 
 /// Macro to generate the methods of trait `Value` for the given fields.
 /// Args:
@@ -100,8 +105,20 @@ where
     impl_value_on_struct_fields!(x, y, z);
 }
 
+impl<T> Value for Point4d<T>
+where
+    Primitive: From<T>,
+    T: Value,
+{
+    impl_value_on_struct_fields!(x, y, z, w);
+}
+
 impl Value for kittycad_modeling_cmds::shared::Color {
     impl_value_on_struct_fields!(r, g, b, a);
+}
+
+impl Value for kittycad_modeling_cmds::shared::ExportFile {
+    impl_value_on_struct_fields!(name, contents);
 }
 
 /// Layout:


### PR DESCRIPTION
## Background

The `Value` trait lets a Rust type be written to KittyCAD execution plan (KCEP) memory, and read back out of memory. The trait has two methods, `into_parts()` (convert your type into a vec of KCEP `Primitive`) and `from_parts()` (given a vec of KCEP `Primitive`, reconstruct your type). 

## Problem

You have to be careful that your `into_parts()` and `from_parts()` methods use the same order for the fields of your Rust struct. E.g. if `into_parts()` outputs a vec with self.length and self.name, then `from_parts()` must assume its input struct is self.length then self.name.

This is easy, but it's a manual process and a bit error-prone. Additionally, the implementation is pretty boilerplate -- the implementation of `Value` can easily be recursive if all your fields also impl `Value`.

Also, if I'm being honest, handwriting implementations of these traits for every single type in our Modeling API is going to be a pretty big timesink, and it's likely that at some point I lose focus and make a mistake, like putting the fields in the wrong order.

## Solution

Write a macro which generates an impl of Value for a given type. If the human programmer supplies a list of all fields, we can ensure they're being used in the same order in both `from_parts()` and `into_parts()`. And this is actually type-checked -- Rust won't compile the code if you supply an invalid field!

## TODO

- This macro only works for structs. Make a similar macro for enums.