### PR TITLE
More uses for KCEP stack

### DIFF
--- a/execution-plan/src/arithmetic.rs
+++ b/execution-plan/src/arithmetic.rs
@@ -57,10 +57,7 @@ impl UnaryArithmetic {
 
 macro_rules! arithmetic_body {
     ($arith:ident, $mem:ident, $method:ident) => {
-        match (
-            $arith.operand0.eval(&$mem)?.clone(),
-            $arith.operand1.eval(&$mem)?.clone(),
-        ) {
+        match ($arith.operand0.eval($mem)?.clone(), $arith.operand1.eval($mem)?.clone()) {
             // If both operands are numeric, then do the arithmetic operation.
             (Primitive::NumericValue(x), Primitive::NumericValue(y)) => {
                 let num = match (x, y) {
@@ -96,8 +93,8 @@ macro_rules! arithmetic_body {
             _ => Err(ExecutionError::CannotApplyOperation {
                 op: $arith.operation.into(),
                 operands: vec![
-                    $arith.operand0.eval(&$mem)?.clone().to_owned(),
-                    $arith.operand1.eval(&$mem)?.clone().to_owned(),
+                    $arith.operand0.eval($mem)?.clone().to_owned(),
+                    $arith.operand1.eval($mem)?.clone().to_owned(),
                 ],
             }),
         }
@@ -106,7 +103,7 @@ macro_rules! arithmetic_body {
 impl BinaryArithmetic {
     /// Calculate the the arithmetic equation.
     /// May read values from the given memory.
-    pub fn calculate(self, mem: &Memory) -> Result<Primitive, ExecutionError> {
+    pub fn calculate(self, mem: &mut Memory) -> Result<Primitive, ExecutionError> {
         use std::ops::{Add, Div, Mul, Sub};
         match self.operation {
             BinaryOperation::Add => {

--- a/execution-plan/src/tests.rs
+++ b/execution-plan/src/tests.rs
@@ -48,7 +48,7 @@ async fn add_literals() {
             operand0: Operand::Literal(3u32.into()),
             operand1: Operand::Literal(2u32.into()),
         },
-        destination: Address(1),
+        destination: Destination::Address(Address(1)),
     }];
     let mut mem = Memory::default();
     let client = test_client().await;
@@ -68,7 +68,7 @@ async fn add_stack() {
                 operand0: Operand::Literal(20u32.into()),
                 operand1: Operand::StackPop,
             },
-            destination: Address(0),
+            destination: Destination::Address(Address(0)),
         },
     ];
     let mut mem = Memory::default();
@@ -92,7 +92,7 @@ async fn add_literal_to_reference() {
                 operand0: Operand::Reference(Address(0)),
                 operand1: Operand::Literal(20u32.into()),
             },
-            destination: Address(1),
+            destination: Destination::Address(Address(1)),
         },
     ];
     // 20 + 450 = 470
@@ -128,7 +128,7 @@ async fn add_to_composite_value() {
                 operand0: Operand::Reference(start_addr),
                 operand1: Operand::Literal(40u32.into()),
             },
-            destination: start_addr,
+            destination: Destination::Address(start_addr),
         }],
         client,
     )

--- a/execution-plan/src/tests.rs
+++ b/execution-plan/src/tests.rs
@@ -57,6 +57,27 @@ async fn add_literals() {
 }
 
 #[tokio::test]
+async fn add_stack() {
+    let plan = vec![
+        Instruction::StackPush {
+            data: vec![10u32.into()],
+        },
+        Instruction::BinaryArithmetic {
+            arithmetic: BinaryArithmetic {
+                operation: BinaryOperation::Add,
+                operand0: Operand::Literal(20u32.into()),
+                operand1: Operand::StackPop,
+            },
+            destination: Address(0),
+        },
+    ];
+    let mut mem = Memory::default();
+    let client = test_client().await;
+    execute(&mut mem, plan, client).await.expect("failed to execute plan");
+    assert_eq!(mem.get(&Address(0)), Some(&30u32.into()))
+}
+
+#[tokio::test]
 async fn add_literal_to_reference() {
     let plan = vec![
         // Memory addr 0 contains 450


### PR DESCRIPTION
Now you can use the stack pop as an operand to arithmetic. New instruction for pushing to the stack helps.