### PR TITLE
Execution-plan: log events, show in debugger

### DIFF
--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -1,4 +1,4 @@
-use kittycad_execution_plan::{Event, ExecutionState, Instruction};
+use kittycad_execution_plan::{BinaryArithmetic, Event, ExecutionState, Instruction};
 use kittycad_execution_plan_traits::Primitive;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -152,21 +152,24 @@ fn make_events_view<'a>(block: Block<'a>, events: &[Event]) -> Table<'a> {
         .iter()
         .cloned()
         .enumerate()
-        .map(|(i, event)| Row::new(vec![i.to_string(), event.text]));
+        .map(|(i, event)| Row::new(vec![i.to_string(), event.severity.to_string(), event.text]));
 
     Table::new(
         rows,
         [
-            // Address
+            // Event number
             Constraint::Length(4),
-            // Value
+            // Event severity
+            Constraint::Length(5),
+            // Message
             Constraint::Max(50),
         ],
     )
     .column_spacing(1)
-    .header(Row::new(vec!["Address", "Value"]).style(Style::new().bold()))
+    .header(Row::new(vec!["#", "Level", "Msg"]).style(Style::new().bold()))
     .block(block)
 }
+
 fn make_memory_view<'a>(block: Block<'a>, mem: &kittycad_execution_plan::Memory, num_rows: usize) -> Table<'a> {
     let rows = mem
         .addresses
@@ -232,7 +235,18 @@ fn make_history_view<'a>(block: Block<'a>, ctx: &Context) -> Table<'a> {
                 Instruction::BinaryArithmetic {
                     arithmetic,
                     destination,
-                } => ("BinaryArithmetic", format!("Set {destination:?}\nto {arithmetic:?}")),
+                } => {
+                    let BinaryArithmetic {
+                        operation,
+                        operand0,
+                        operand1,
+                    } = arithmetic;
+                    let arith_description = format!("{operand0:?} {operation} {operand1:?}");
+                    (
+                        "BinaryArithmetic",
+                        format!("Set {destination:?}\nto {arith_description}"),
+                    )
+                }
                 Instruction::UnaryArithmetic {
                     arithmetic,
                     destination,

--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -269,7 +269,13 @@ fn make_history_view<'a>(block: Block<'a>, ctx: &Context) -> Table<'a> {
                     destination,
                 } => ("UnaryArithmetic", format!("Set {destination:?}\nto {arithmetic:?}")),
                 Instruction::StackPush { data } => ("StackPush", format!("{data:?}")),
-                Instruction::StackPop { destination } => ("StackPop", format!("{destination:?}")),
+                Instruction::StackPop { destination } => (
+                    "StackPop",
+                    match destination {
+                        Some(dst) => format!("Into: {dst:?}"),
+                        None => "Discard".to_owned(),
+                    },
+                ),
             };
             let height = operands.chars().filter(|ch| ch == &'\n').count() + 1;
             Row::new(vec![(i + 1).to_string(), instr_type.to_owned(), operands])

--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -109,7 +109,6 @@ pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
 
 fn make_stack_view<'a>(block: Block<'a>, stack: &kittycad_execution_plan::Stack<Vec<Primitive>>) -> Table<'a> {
     let rows = stack
-        .inner
         .iter()
         .enumerate()
         .map(|(depth, val)| Row::new(vec![depth.to_string(), format!("{val:?}")]));
@@ -164,6 +163,7 @@ fn make_history_view<'a>(block: Block<'a>, ctx: &Context) -> Table<'a> {
             ExecutionState {
                 mem: _,
                 active_instruction,
+                events: _,
             },
         )| {
             let instruction = &ctx.plan[*active_instruction];

--- a/execution-plan-debugger/test_input.json
+++ b/execution-plan-debugger/test_input.json
@@ -115,6 +115,8 @@
         }
     },
     {
-        "StackPop": {}
+        "StackPop": {
+            "destination": 10
+        }
     }
 ]

--- a/execution-plan-debugger/test_input.json
+++ b/execution-plan-debugger/test_input.json
@@ -22,7 +22,11 @@
     },
     {
         "StackPush": {
-            "data": [{"String": "foo"}]
+            "data": [
+                {
+                    "String": "foo"
+                }
+            ]
         }
     },
     {
@@ -55,6 +59,26 @@
             "value": {
                 "NumericValue": {
                     "UInteger": 1
+                }
+            }
+        }
+    },
+    {
+        "BinaryArithmetic": {
+            "destination": {
+                "Address": 4
+            },
+            "arithmetic": {
+                "operation": "Add",
+                "operand0": {
+                    "Reference": 4
+                },
+                "operand1": {
+                    "Literal": {
+                        "NumericValue": {
+                            "Integer": 55
+                        }
+                    }
                 }
             }
         }

--- a/execution-plan/src/address.rs
+++ b/execution-plan/src/address.rs
@@ -7,7 +7,7 @@ pub struct Address(pub(crate) usize);
 
 impl fmt::Debug for Address {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Addr({})", self.0)
+        write!(f, "Addr{}", self.0)
     }
 }
 

--- a/execution-plan/src/address.rs
+++ b/execution-plan/src/address.rs
@@ -11,6 +11,12 @@ impl fmt::Debug for Address {
     }
 }
 
+impl fmt::Display for Address {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl Address {
     /// First memory address available.
     pub const ZERO: Self = Self(0);
@@ -63,12 +69,6 @@ impl std::ops::Sub for Address {
 
     fn sub(self, rhs: Self) -> Self::Output {
         self.0 - rhs.0
-    }
-}
-
-impl fmt::Display for Address {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
     }
 }
 

--- a/execution-plan/src/arithmetic.rs
+++ b/execution-plan/src/arithmetic.rs
@@ -67,7 +67,7 @@ macro_rules! arithmetic_body {
             severity: crate::events::Severity::Info,
         });
         $events.push(crate::events::Event {
-            text: "Evaluating left operand".to_owned(),
+            text: "Evaluating right operand".to_owned(),
             severity: crate::events::Severity::Info,
         });
         let r = $arith.operand1.eval($mem)?.clone();
@@ -105,7 +105,12 @@ macro_rules! arithmetic_body {
                         NumericPrimitive::Integer((x as i64).$method(y))
                     }
                 };
-                Ok(Primitive::NumericValue(num))
+                let prim = Primitive::NumericValue(num);
+                $events.push(crate::events::Event {
+                    text: format!("Output is {prim:?}"),
+                    severity: crate::events::Severity::Info,
+                });
+                Ok(prim)
             }
             // This operation can only be done on numeric types.
             _ => Err(ExecutionError::CannotApplyOperation {

--- a/execution-plan/src/arithmetic.rs
+++ b/execution-plan/src/arithmetic.rs
@@ -59,7 +59,7 @@ macro_rules! arithmetic_body {
     ($arith:ident, $mem:ident, $method:ident, $events:ident) => {{
         $events.push(crate::events::Event {
             text: "Evaluating left operand".to_owned(),
-            severity: crate::events::Severity::Info,
+            severity: crate::events::Severity::Debug,
         });
         let l = $arith.operand0.eval($mem)?.clone();
         $events.push(crate::events::Event {
@@ -68,7 +68,7 @@ macro_rules! arithmetic_body {
         });
         $events.push(crate::events::Event {
             text: "Evaluating right operand".to_owned(),
-            severity: crate::events::Severity::Info,
+            severity: crate::events::Severity::Debug,
         });
         let r = $arith.operand1.eval($mem)?.clone();
         $events.push(crate::events::Event {

--- a/execution-plan/src/arithmetic.rs
+++ b/execution-plan/src/arithmetic.rs
@@ -2,7 +2,7 @@ use kittycad_execution_plan_traits::{NumericPrimitive, Primitive};
 use serde::{Deserialize, Serialize};
 
 use self::operator::{BinaryOperation, UnaryOperation};
-use crate::{ExecutionError, Memory, Operand};
+use crate::{events::EventWriter, ExecutionError, Memory, Operand};
 
 pub mod operator;
 
@@ -56,8 +56,26 @@ impl UnaryArithmetic {
 }
 
 macro_rules! arithmetic_body {
-    ($arith:ident, $mem:ident, $method:ident) => {
-        match ($arith.operand0.eval($mem)?.clone(), $arith.operand1.eval($mem)?.clone()) {
+    ($arith:ident, $mem:ident, $method:ident, $events:ident) => {{
+        $events.push(crate::events::Event {
+            text: "Evaluating left operand".to_owned(),
+            severity: crate::events::Severity::Info,
+        });
+        let l = $arith.operand0.eval($mem)?.clone();
+        $events.push(crate::events::Event {
+            text: format!("Left operand is {l:?}"),
+            severity: crate::events::Severity::Info,
+        });
+        $events.push(crate::events::Event {
+            text: "Evaluating left operand".to_owned(),
+            severity: crate::events::Severity::Info,
+        });
+        let r = $arith.operand1.eval($mem)?.clone();
+        $events.push(crate::events::Event {
+            text: format!("Right operand is {r:?}"),
+            severity: crate::events::Severity::Info,
+        });
+        match (l, r) {
             // If both operands are numeric, then do the arithmetic operation.
             (Primitive::NumericValue(x), Primitive::NumericValue(y)) => {
                 let num = match (x, y) {
@@ -98,25 +116,25 @@ macro_rules! arithmetic_body {
                 ],
             }),
         }
-    };
+    }};
 }
 impl BinaryArithmetic {
     /// Calculate the the arithmetic equation.
     /// May read values from the given memory.
-    pub fn calculate(self, mem: &mut Memory) -> Result<Primitive, ExecutionError> {
+    pub fn calculate(self, mem: &mut Memory, events: &mut EventWriter) -> Result<Primitive, ExecutionError> {
         use std::ops::{Add, Div, Mul, Sub};
         match self.operation {
             BinaryOperation::Add => {
-                arithmetic_body!(self, mem, add)
+                arithmetic_body!(self, mem, add, events)
             }
             BinaryOperation::Mul => {
-                arithmetic_body!(self, mem, mul)
+                arithmetic_body!(self, mem, mul, events)
             }
             BinaryOperation::Sub => {
-                arithmetic_body!(self, mem, sub)
+                arithmetic_body!(self, mem, sub, events)
             }
             BinaryOperation::Div => {
-                arithmetic_body!(self, mem, div)
+                arithmetic_body!(self, mem, div, events)
             }
         }
     }

--- a/execution-plan/src/events.rs
+++ b/execution-plan/src/events.rs
@@ -2,7 +2,9 @@
 /// Meant for debugging by a human.
 #[derive(Debug, Clone)]
 pub struct Event {
+    /// What happened in the event.
     pub text: String,
+    /// How important the event was.
     pub severity: Severity,
 }
 

--- a/execution-plan/src/events.rs
+++ b/execution-plan/src/events.rs
@@ -1,3 +1,6 @@
+//! Events can be logged during execution.
+//! Used in the visual debugger.
+
 /// Something that happened during execution.
 /// Meant for debugging by a human.
 #[derive(Debug, Clone)]
@@ -9,15 +12,19 @@ pub struct Event {
 }
 
 /// How important the event is.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Severity {
+    /// Info
     Info,
+    /// Debug
+    Debug,
 }
 
 impl std::fmt::Display for Severity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
             Severity::Info => "Info",
+            Severity::Debug => "Debug",
         };
         write!(f, "{s}")
     }

--- a/execution-plan/src/events.rs
+++ b/execution-plan/src/events.rs
@@ -14,6 +14,15 @@ pub enum Severity {
     Info,
 }
 
+impl std::fmt::Display for Severity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Severity::Info => "Info",
+        };
+        write!(f, "{s}")
+    }
+}
+
 /// Tracks events that occur during execution.
 #[derive(Debug, Default, Clone)]
 pub struct EventWriter {

--- a/execution-plan/src/events.rs
+++ b/execution-plan/src/events.rs
@@ -1,0 +1,34 @@
+/// Something that happened during execution.
+/// Meant for debugging by a human.
+#[derive(Debug, Clone)]
+pub struct Event {
+    pub text: String,
+    pub severity: Severity,
+}
+
+/// How important the event is.
+#[derive(Debug, Clone, Copy)]
+pub enum Severity {
+    Info,
+}
+
+/// Tracks events that occur during execution.
+#[derive(Debug, Default, Clone)]
+pub struct EventWriter {
+    inner: Vec<Event>,
+}
+
+impl EventWriter {
+    /// Add a new event.
+    pub fn push(&mut self, event: Event) {
+        self.inner.push(event);
+    }
+    /// Iterate over all events.
+    pub fn iter(&self) -> impl Iterator<Item = &Event> {
+        self.inner.iter()
+    }
+    /// Remove all events, resetting the writer.
+    pub fn drain(&mut self) -> Vec<Event> {
+        std::mem::take(&mut self.inner)
+    }
+}

--- a/execution-plan/src/lib.rs
+++ b/execution-plan/src/lib.rs
@@ -6,8 +6,7 @@
 //! You can think of it as a domain-specific language for making KittyCAD API calls and using
 //! the results to make other API calls.
 
-pub use events::Event;
-use events::EventWriter;
+use events::{Event, EventWriter};
 use kittycad_execution_plan_traits::{FromMemory, MemoryError, Primitive, ReadMemory};
 use kittycad_modeling_cmds::{each_cmd, id::ModelingCmdId};
 use kittycad_modeling_session::{RunCommandError, Session as ModelingSession};
@@ -23,7 +22,7 @@ pub use self::instruction::Instruction;
 
 mod address;
 mod arithmetic;
-mod events;
+pub mod events;
 mod instruction;
 mod memory;
 #[cfg(test)]

--- a/execution-plan/src/lib.rs
+++ b/execution-plan/src/lib.rs
@@ -6,7 +6,8 @@
 //! You can think of it as a domain-specific language for making KittyCAD API calls and using
 //! the results to make other API calls.
 
-use events::{Event, EventWriter};
+pub use events::Event;
+use events::EventWriter;
 use kittycad_execution_plan_traits::{FromMemory, MemoryError, Primitive, ReadMemory};
 use kittycad_modeling_cmds::{each_cmd, id::ModelingCmdId};
 use kittycad_modeling_session::{RunCommandError, Session as ModelingSession};

--- a/execution-plan/src/memory.rs
+++ b/execution-plan/src/memory.rs
@@ -228,9 +228,7 @@ fn pretty_print(p: &Primitive) -> (&'static str, String) {
 /// A stack where values can be pushed/popped.
 #[derive(Debug, Eq, PartialEq, Default, Clone)]
 pub struct Stack<T> {
-    // TODO: should not be pub
-    #[doc(hidden)]
-    pub inner: Vec<T>,
+    inner: Vec<T>,
 }
 
 impl<T> Stack<T> {
@@ -245,6 +243,10 @@ impl<T> Stack<T> {
     /// Is the stack empty?
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
+    }
+    /// Iterate over the stack, from top to bottom.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        self.inner.iter().rev()
     }
 }
 


### PR DESCRIPTION
Executing a KCEP instruction can now emit events. Events have a severity, and some message text.

Each instruction's events are shown in the debugger (see bottom-left box).

<img width="850" alt="Screenshot 2024-02-02 at 5 29 25 PM" src="https://github.com/KittyCAD/modeling-api/assets/5407457/ae959a95-4096-4557-bfe7-52816067d704">

Events are color-coded by severity.
