### PR TITLE
EP debugger: color highlighting for memory addresses

### DIFF
--- a/execution-plan-debugger/src/app.rs
+++ b/execution-plan-debugger/src/app.rs
@@ -8,7 +8,6 @@ const REFRESH_RATE: Duration = Duration::from_millis(250);
 /// Probably immutable, given by the parent.
 pub struct Context {
     pub history: Vec<kittycad_execution_plan::ExecutionState>,
-    pub result: Result<(), kittycad_execution_plan::ExecutionError>,
     pub plan: Vec<Instruction>,
 }
 

--- a/execution-plan-debugger/src/app.rs
+++ b/execution-plan-debugger/src/app.rs
@@ -20,14 +20,12 @@ pub struct State {
 pub enum HistorySelected {
     Start,
     Instruction(usize),
-    Finish,
 }
 
 impl State {
     pub fn active_instruction(&self) -> HistorySelected {
         match self.instruction_table_state.selected().unwrap() {
             0 => HistorySelected::Start,
-            x if x == self.num_rows - 1 => HistorySelected::Finish,
             other => HistorySelected::Instruction(other - 1),
         }
     }
@@ -46,7 +44,7 @@ pub fn run(ctx: Context) -> anyhow::Result<()> {
         instruction_table_state,
         // 1 extra row for start (before any instructions),
         // and 1 extra row for the finish result (err/ok).
-        num_rows: ctx.history.len() + 2,
+        num_rows: ctx.history.len() + 1,
     };
 
     loop {

--- a/execution-plan-debugger/src/main.rs
+++ b/execution-plan-debugger/src/main.rs
@@ -22,8 +22,8 @@ async fn inner_main() -> Result<()> {
     let plan = get_instrs()?;
     let mut mem = kittycad_execution_plan::Memory::default();
     let session = None;
-    let (history, result) = kittycad_execution_plan::execute_time_travel(&mut mem, plan.clone(), session).await;
-    app::run(app::Context { history, result, plan })
+    let history = kittycad_execution_plan::execute_time_travel(&mut mem, plan.clone(), session).await;
+    app::run(app::Context { history, plan })
 }
 
 fn get_instrs() -> Result<Vec<Instruction>> {

--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -339,10 +339,6 @@ fn make_history_view<'a>(block: Block<'a>, ctx: &Context, instrs_with_errors: &H
             .height(height.try_into().expect("height of cell must fit into u16"))
         },
     ));
-    rows.push(Row::new(vec![
-        Cell::new((ctx.history.len() + 1).to_string()),
-        Cell::new(Text::from("Terminated")),
-    ]));
     Table::new(
         rows,
         [

--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -90,32 +90,31 @@ pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
     let (event_view, addr_colors) = make_events_view(event_block, events);
 
     // Render the main memory view.
+    let main_mem_block = Block::default()
+        .borders(Borders::ALL)
+        .style(Style::default())
+        .padding(Padding::vertical(1))
+        .title("Address Memory");
     let main_mem_view = match state.active_instruction() {
         HistorySelected::Instruction(active_instruction) => {
             let mem = &ctx.history[active_instruction].mem;
-            let block = Block::default()
-                .borders(Borders::ALL)
-                .style(Style::default())
-                .padding(Padding::vertical(1))
-                .title("Address Memory");
-            Some(make_memory_view(block, mem, addr_colors))
-            // Some(make_memory_view(block, mem, num_memory_rows, addr_colors))
+            make_memory_view(main_mem_block, mem, addr_colors)
         }
-        _ => None,
+        _ => Table::new(Vec::<Row>::new(), Vec::<Constraint>::new()).block(main_mem_block),
     };
 
     // Render the stack view.
+    let stack_view_block = Block::default()
+        .borders(Borders::ALL)
+        .style(Style::default())
+        .padding(Padding::vertical(1))
+        .title("Stack Memory");
     let stack_mem_view = match state.active_instruction() {
         HistorySelected::Instruction(active_instruction) => {
             let mem = &ctx.history[active_instruction].mem;
-            let block = Block::default()
-                .borders(Borders::ALL)
-                .style(Style::default())
-                .padding(Padding::vertical(1))
-                .title("Stack Memory");
-            Some(make_stack_view(block, &mem.stack))
+            make_stack_view(stack_view_block, &mem.stack)
         }
-        _ => None,
+        _ => Table::new(Vec::<Row>::new(), Vec::<Constraint>::new()).block(stack_view_block),
     };
 
     let footer = Paragraph::new(Text::styled(
@@ -127,12 +126,8 @@ pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
     f.render_stateful_widget(history_view, left_chunks[0], &mut state.instruction_table_state);
     f.render_widget(event_view, left_chunks[1]);
     f.render_widget(title, chunks[0]);
-    if let Some(view) = main_mem_view {
-        f.render_widget(view, right_chunks[0]);
-    }
-    if let Some(view) = stack_mem_view {
-        f.render_widget(view, right_chunks[1]);
-    }
+    f.render_widget(main_mem_view, right_chunks[0]);
+    f.render_widget(stack_mem_view, right_chunks[1]);
     f.render_widget(footer, chunks[2]);
 }
 

--- a/execution-plan-debugger/test_input.json
+++ b/execution-plan-debugger/test_input.json
@@ -66,7 +66,7 @@
     {
         "BinaryArithmetic": {
             "destination": {
-                "Address": 4
+                "Address": 8
             },
             "arithmetic": {
                 "operation": "Add",
@@ -74,11 +74,7 @@
                     "Reference": 4
                 },
                 "operand1": {
-                    "Literal": {
-                        "NumericValue": {
-                            "Integer": 55
-                        }
-                    }
+                    "Reference": 1 
                 }
             }
         }

--- a/execution-plan/src/address.rs
+++ b/execution-plan/src/address.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// An address in KCEP's program memory.
-#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct Address(pub(crate) usize);
 
 impl fmt::Debug for Address {

--- a/execution-plan/src/arithmetic.rs
+++ b/execution-plan/src/arithmetic.rs
@@ -57,24 +57,24 @@ impl UnaryArithmetic {
 
 macro_rules! arithmetic_body {
     ($arith:ident, $mem:ident, $method:ident, $events:ident) => {{
-        $events.push(crate::events::Event {
-            text: "Evaluating left operand".to_owned(),
-            severity: crate::events::Severity::Debug,
-        });
+        $events.push(crate::events::Event::new(
+            "Evaluating left operand".to_owned(),
+            crate::events::Severity::Debug,
+        ));
         let l = $arith.operand0.eval($mem)?.clone();
-        $events.push(crate::events::Event {
-            text: format!("Left operand is {l:?}"),
-            severity: crate::events::Severity::Info,
-        });
-        $events.push(crate::events::Event {
-            text: "Evaluating right operand".to_owned(),
-            severity: crate::events::Severity::Debug,
-        });
+        $events.push(crate::events::Event::new(
+            format!("Left operand is {l:?}"),
+            crate::events::Severity::Info,
+        ));
+        $events.push(crate::events::Event::new(
+            "Evaluating right operand".to_owned(),
+            crate::events::Severity::Debug,
+        ));
         let r = $arith.operand1.eval($mem)?.clone();
-        $events.push(crate::events::Event {
-            text: format!("Right operand is {r:?}"),
-            severity: crate::events::Severity::Info,
-        });
+        $events.push(crate::events::Event::new(
+            format!("Right operand is {r:?}"),
+            crate::events::Severity::Info,
+        ));
         match (l, r) {
             // If both operands are numeric, then do the arithmetic operation.
             (Primitive::NumericValue(x), Primitive::NumericValue(y)) => {
@@ -106,10 +106,10 @@ macro_rules! arithmetic_body {
                     }
                 };
                 let prim = Primitive::NumericValue(num);
-                $events.push(crate::events::Event {
-                    text: format!("Output is {prim:?}"),
-                    severity: crate::events::Severity::Info,
-                });
+                $events.push(crate::events::Event::new(
+                    format!("Output is {prim:?}"),
+                    crate::events::Severity::Info,
+                ));
                 Ok(prim)
             }
             // This operation can only be done on numeric types.

--- a/execution-plan/src/arithmetic.rs
+++ b/execution-plan/src/arithmetic.rs
@@ -62,19 +62,25 @@ macro_rules! arithmetic_body {
             crate::events::Severity::Debug,
         ));
         let l = $arith.operand0.eval($mem)?.clone();
-        $events.push(crate::events::Event::new(
-            format!("Left operand is {l:?}"),
-            crate::events::Severity::Info,
-        ));
+        $events.push({
+            let mut evt = crate::events::Event::new(format!("Left operand is {l:?}"), crate::events::Severity::Info);
+            if let Operand::Reference(a) = $arith.operand0 {
+                evt.related_address = Some(a);
+            }
+            evt
+        });
         $events.push(crate::events::Event::new(
             "Evaluating right operand".to_owned(),
             crate::events::Severity::Debug,
         ));
         let r = $arith.operand1.eval($mem)?.clone();
-        $events.push(crate::events::Event::new(
-            format!("Right operand is {r:?}"),
-            crate::events::Severity::Info,
-        ));
+        $events.push({
+            let mut evt = crate::events::Event::new(format!("Right operand is {r:?}"), crate::events::Severity::Info);
+            if let Operand::Reference(a) = $arith.operand1 {
+                evt.related_address = Some(a);
+            }
+            evt
+        });
         match (l, r) {
             // If both operands are numeric, then do the arithmetic operation.
             (Primitive::NumericValue(x), Primitive::NumericValue(y)) => {

--- a/execution-plan/src/events.rs
+++ b/execution-plan/src/events.rs
@@ -11,6 +11,13 @@ pub struct Event {
     pub severity: Severity,
 }
 
+impl Event {
+    /// New event, with other fields set to their default.
+    pub fn new(text: String, severity: Severity) -> Self {
+        Self { text, severity }
+    }
+}
+
 /// How important the event is.
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Severity {

--- a/execution-plan/src/events.rs
+++ b/execution-plan/src/events.rs
@@ -1,6 +1,8 @@
 //! Events can be logged during execution.
 //! Used in the visual debugger.
 
+use crate::Address;
+
 /// Something that happened during execution.
 /// Meant for debugging by a human.
 #[derive(Debug, Clone)]
@@ -9,12 +11,19 @@ pub struct Event {
     pub text: String,
     /// How important the event was.
     pub severity: Severity,
+    /// This event might be about a particular address.
+    /// Debuggers might want to visualize this.
+    pub related_address: Option<Address>,
 }
 
 impl Event {
     /// New event, with other fields set to their default.
     pub fn new(text: String, severity: Severity) -> Self {
-        Self { text, severity }
+        Self {
+            text,
+            severity,
+            related_address: None,
+        }
     }
 }
 

--- a/execution-plan/src/events.rs
+++ b/execution-plan/src/events.rs
@@ -30,6 +30,8 @@ impl Event {
 /// How important the event is.
 #[derive(Debug, Clone, Copy, Ord, PartialOrd, Eq, PartialEq)]
 pub enum Severity {
+    /// Error
+    Error,
     /// Info
     Info,
     /// Debug
@@ -39,6 +41,7 @@ pub enum Severity {
 impl std::fmt::Display for Severity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = match self {
+            Severity::Error => "Error",
             Severity::Info => "Info",
             Severity::Debug => "Debug",
         };

--- a/execution-plan/src/instruction.rs
+++ b/execution-plan/src/instruction.rs
@@ -122,7 +122,7 @@ impl Instruction {
                 match destination {
                     Destination::Address(addr) => {
                         events.push(Event {
-                            text: format!("writing output to address {addr}"),
+                            text: format!("Writing output to address {addr}"),
                             severity: crate::events::Severity::Info,
                             related_address: Some(addr),
                         });

--- a/execution-plan/src/instruction.rs
+++ b/execution-plan/src/instruction.rs
@@ -120,7 +120,14 @@ impl Instruction {
             } => {
                 let out = arithmetic.calculate(mem, events)?;
                 match destination {
-                    Destination::Address(addr) => mem.set(addr, out),
+                    Destination::Address(addr) => {
+                        events.push(Event {
+                            text: format!("writing output to address {addr}"),
+                            severity: crate::events::Severity::Info,
+                            related_address: Some(addr),
+                        });
+                        mem.set(addr, out);
+                    }
                     Destination::StackPush => mem.stack.push(vec![out]),
                 };
             }

--- a/execution-plan/src/instruction.rs
+++ b/execution-plan/src/instruction.rs
@@ -200,12 +200,14 @@ impl Instruction {
                 events.push(Event {
                     text: format!("Reading size of element from {curr}"),
                     severity: crate::events::Severity::Info,
+                    related_address: Some(curr),
                 });
                 let size_of_element: usize = mem.get_primitive(&curr)?;
                 let addr_of_element = curr + 1;
                 events.push(Event {
                     text: format!("Element begins at {addr_of_element} and has length {size_of_element}"),
                     severity: crate::events::Severity::Info,
+                    related_address: Some(addr_of_element),
                 });
                 let element = mem.get_slice(addr_of_element, size_of_element)?;
                 mem.stack.push(element);
@@ -247,12 +249,14 @@ impl Instruction {
                 events.push(Event {
                     text: format!("Reading size of property from {curr}"),
                     severity: crate::events::Severity::Info,
+                    related_address: Some(curr),
                 });
                 let size_of_element: usize = mem.get_size(&curr)?;
                 let addr_of_element = curr + 1;
                 events.push(Event {
                     text: format!("Property begins at {addr_of_element} and has length {size_of_element}"),
                     severity: crate::events::Severity::Info,
+                    related_address: Some(addr_of_element),
                 });
                 let element = mem.get_slice(addr_of_element, size_of_element)?;
                 mem.stack.push(element);


### PR DESCRIPTION
# Memory highlighter

If an instruction touches some address, the address gets highlighted in color! E.g. this instruction writes to address 8, so the address becomes purple in both the event log and the memory visualizer.  It also reads from address 1 and 4, which become blue and green.

![debugger memory highlights](https://github.com/KittyCAD/modeling-api/assets/5407457/3ef94896-5acb-4e2c-b381-842fce62b564)

# Other UI improvements

If the execution plan failed (i.e. an instruction returned Err instead of Ok), the error is now shown in the Events for that instruction 

https://github.com/KittyCAD/modeling-api/assets/5407457/742b3269-8584-4c11-b122-b96e98ec7a0e


