### PR TITLE
Instruction::Copy becomes CopyLen

### DIFF
--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -363,13 +363,9 @@ fn describe_instruction(instruction: &Instruction) -> (&'static str, String) {
                 None => "Discard".to_owned(),
             },
         ),
-        Instruction::Copy {
-            source,
-            destination,
-            num_primitives,
-        } => (
-            "Copy",
-            format!("{num_primitives:?} prims from {source:?} to {destination:?}"),
-        ),
+        Instruction::CopyLen {
+            source_range,
+            destination_range,
+        } => ("Copy", format!("copy from {source_range:?} to {destination_range:?}")),
     }
 }

--- a/execution-plan/src/tests.rs
+++ b/execution-plan/src/tests.rs
@@ -241,6 +241,57 @@ async fn get_element_of_array() {
 }
 
 #[tokio::test]
+async fn copy_len() {
+    // Initialize memory with a single object:
+    // { first: <3d point>, second: <4d point> }
+    let mut smem = StaticMemoryInitializer::default();
+    let size_of_object = 9;
+    smem.push(Primitive::from(ObjectHeader {
+        properties: vec!["first".to_owned(), "second".to_owned()],
+        size: size_of_object,
+    }));
+    smem.push(Primitive::from(3usize));
+    smem.push(Point3d {
+        x: 12.0f64,
+        y: 13.0,
+        z: 14.0,
+    });
+    smem.push(Primitive::from(4usize));
+    smem.push(Point4d {
+        x: 20.0f64,
+        y: 21.0,
+        z: 22.0,
+        w: 23.0,
+    });
+    let mut mem = smem.finish();
+
+    // Addr 5 is a property of the object at addr 0.
+    // Its key is "second" and its value is a Point4d.
+    // The property is preceded by its length (4) because that's just how KCEP stores objects.
+    // Push that address onto the stack.
+    let start_of_second_property = Address::ZERO + 5;
+    mem.stack.push(vec![(start_of_second_property).into()]);
+
+    // Copy the value at addr 5 into addr 100.
+    let copied_into = Address::ZERO + 100;
+    execute(
+        &mut mem,
+        vec![Instruction::CopyLen {
+            source_range: Operand::StackPop,
+            destination_range: Operand::Literal(Primitive::Address(copied_into)),
+        }],
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Assert that the property was properly copied into the destination.
+    assert_eq!(mem.get(&copied_into), mem.get(&(start_of_second_property + 1)));
+    assert_eq!(mem.get(&(copied_into + 1)), mem.get(&(start_of_second_property + 2)));
+    assert_eq!(mem.get(&(copied_into + 2)), mem.get(&(start_of_second_property + 3)));
+}
+
+#[tokio::test]
 async fn get_key_of_object() {
     let point_4d = Point4d {
         x: 20.0f64,
@@ -264,7 +315,6 @@ async fn get_key_of_object() {
     smem.push(Primitive::from(4usize));
     smem.push(point_4d);
     let mut mem = smem.finish();
-    println!("{}", mem.debug_table(None));
     execute(
         &mut mem,
         vec![Instruction::AddrOfMember {
@@ -280,8 +330,6 @@ async fn get_key_of_object() {
     // Check it's there.
     let actual = mem.stack.pop().unwrap();
     assert_eq!(actual, vec![(Address::ZERO + 5).into()]);
-    assert!(mem.get(&(Address::ZERO + size)).is_some());
-    assert!(mem.get(&(Address::ZERO + size + 1)).is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
This fits better with how KCL stores arrays/objects in KCEP. Each element of the structure is prefixed by its length.