### PR TITLE
Rename macro modules

### DIFF
--- a/modeling-cmds-macros/src/lib.rs
+++ b/modeling-cmds-macros/src/lib.rs
@@ -1,11 +1,11 @@
 //! Proc-macros for implementing kittycad-modeling-cmds traits.
 
-mod derive_modeling_cmd_variant;
 mod modeling_cmd_enum;
 mod modeling_cmd_output;
+mod modeling_cmd_variant;
 
 use proc_macro::TokenStream;
-use syn::{ItemMod, DeriveInput};
+use syn::{DeriveInput, ItemMod};
 
 /// This will derive the trait `ModelingCmdVariant` from the `kittycad-modeling-cmds` crate.
 /// Its associated type `output` will be ().
@@ -17,7 +17,7 @@ pub fn derive_modeling_cmd_variant_empty(input: TokenStream) -> TokenStream {
     // Then hand them back to the compiler.
     // It's idiomatic to make your proc macros a thin wrapper around an "impl" function, because it
     // simplifies unit testing. This is recommended in The Rust Book.
-    TokenStream::from(derive_modeling_cmd_variant::impl_empty(input))
+    TokenStream::from(modeling_cmd_variant::derive_empty(input))
 }
 
 /// This will derive the trait `ModelingCmdVariant` from the `kittycad-modeling-cmds` crate.
@@ -26,7 +26,7 @@ pub fn derive_modeling_cmd_variant_empty(input: TokenStream) -> TokenStream {
 pub fn derive_modeling_cmd_variant_nonempty(input: TokenStream) -> TokenStream {
     // For comments, see `derive_modeling_cmd_variant_empty`.
     let input: DeriveInput = syn::parse2(input.into()).unwrap();
-    TokenStream::from(derive_modeling_cmd_variant::impl_nonempty(input))
+    TokenStream::from(modeling_cmd_variant::derive_nonempty(input))
 }
 
 /// Generates the ModelingCmd enum from all its variants.

--- a/modeling-cmds-macros/src/modeling_cmd_variant.rs
+++ b/modeling-cmds-macros/src/modeling_cmd_variant.rs
@@ -1,15 +1,15 @@
-use proc_macro2::{TokenStream};
+use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::{spanned::Spanned, DeriveInput};
 
-pub(crate) fn impl_empty(input: DeriveInput) -> TokenStream {
+pub(crate) fn derive_empty(input: DeriveInput) -> TokenStream {
     // Where in the input source code is this type defined?
     let span = input.span();
     // Name of type that is deriving the trait.
     let name = input.ident;
     // Delegate to a macro that can generate code for this specific type.
     match input.data {
-        syn::Data::Struct(_) => impl_empty_on_struct(name),
+        syn::Data::Struct(_) => derive_empty_on_struct(name),
         syn::Data::Enum(_) => quote_spanned! {span =>
             compile_error!("ModelingCmdVariant cannot be implemented on an enum type")
         },
@@ -19,9 +19,7 @@ pub(crate) fn impl_empty(input: DeriveInput) -> TokenStream {
     }
 }
 
-fn impl_empty_on_struct(
-    name: proc_macro2::Ident,
-) -> TokenStream {
+fn derive_empty_on_struct(name: proc_macro2::Ident) -> TokenStream {
     quote! {
         impl kittycad_modeling_cmds::ModelingCmdVariant for #name {
             type Output = ();
@@ -36,12 +34,12 @@ fn impl_empty_on_struct(
     }
 }
 
-// For comments, see `fn impl_empty`.
-pub(crate) fn impl_nonempty(input: DeriveInput) -> TokenStream {
+// For comments, see `fn derive_empty`.
+pub(crate) fn derive_nonempty(input: DeriveInput) -> TokenStream {
     let span = input.span();
     let name = input.ident;
     match input.data {
-        syn::Data::Struct(_) => impl_nonempty_on_struct(name),
+        syn::Data::Struct(_) => derive_nonempty_on_struct(name),
         syn::Data::Enum(_) => quote_spanned! {span =>
             compile_error!("ModelingCmdVariant cannot be implemented on an enum type")
         },
@@ -51,9 +49,7 @@ pub(crate) fn impl_nonempty(input: DeriveInput) -> TokenStream {
     }
 }
 
-fn impl_nonempty_on_struct(
-    name: proc_macro2::Ident,
-) -> TokenStream {
+fn derive_nonempty_on_struct(name: proc_macro2::Ident) -> TokenStream {
     quote! {
         impl kittycad_modeling_cmds::ModelingCmdVariant for #name {
             type Output = kittycad_modeling_cmds::output::#name;


### PR DESCRIPTION
Now they're consistent with each other.