### PR TITLE
Generate an enum with a list of all available ModelingCmds

### DIFF
--- a/execution-plan/src/lib.rs
+++ b/execution-plan/src/lib.rs
@@ -9,7 +9,7 @@
 use events::{Event, EventWriter};
 use kittycad_execution_plan_traits::Address;
 use kittycad_execution_plan_traits::{FromMemory, MemoryError, Primitive, ReadMemory};
-use kittycad_modeling_cmds::{each_cmd, id::ModelingCmdId};
+use kittycad_modeling_cmds::{each_cmd, id::ModelingCmdId, ModelingCmdEndpoint as Endpoint};
 use kittycad_modeling_session::{RunCommandError, Session as ModelingSession};
 pub use memory::{Memory, Stack, StaticMemoryInitializer};
 use serde::{Deserialize, Serialize};
@@ -50,23 +50,6 @@ pub struct ApiRequest {
     pub cmd_id: ModelingCmdId,
 }
 
-/// A KittyCAD modeling command.
-#[derive(Serialize, Deserialize, parse_display_derive::Display, Debug, PartialEq, Clone, Copy)]
-pub enum Endpoint {
-    #[allow(missing_docs)]
-    StartPath,
-    #[allow(missing_docs)]
-    MovePathPen,
-    #[allow(missing_docs)]
-    ExtendPath,
-    #[allow(missing_docs)]
-    ClosePath,
-    #[allow(missing_docs)]
-    Extrude,
-    #[allow(missing_docs)]
-    TakeSnapshot,
-}
-
 impl ApiRequest {
     async fn execute(self, session: &mut ModelingSession, mem: &mut Memory) -> Result<()> {
         let Self {
@@ -101,6 +84,7 @@ impl ApiRequest {
                 let cmd = each_cmd::TakeSnapshot::from_memory(&mut arguments, mem)?;
                 session.run_command(cmd_id, cmd).await?
             }
+            other => panic!("Haven't implemented endpoint {other:?} yet"),
         };
         // Write out to memory.
         if let Some(output_address) = store_response {

--- a/modeling-cmds-macros/src/modeling_cmd_enum.rs
+++ b/modeling-cmds-macros/src/modeling_cmd_enum.rs
@@ -61,8 +61,24 @@ pub(crate) fn generate(input: ItemMod) -> TokenStream {
         /// Commands that the KittyCAD engine can execute.
         #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
         #[serde(rename_all = "snake_case", tag = "type")]
-        pub enum ModelingCmd {
-            #(#[doc = #docs] #variants(kittycad_modeling_cmds::each_cmd::#variants),)*
+        pub enum ModelingCmd {#(
+            #[doc = #docs]
+            #variants(kittycad_modeling_cmds::each_cmd::#variants),
+        )*}
+        /// Each modeling command (no parameters or fields).
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+        pub enum ModelingCmdEndpoint{#(
+            #[doc = #docs]
+            #variants,
+        )*}
+        /// You can easily convert each modeling command with its fields,
+        /// into a modeling command without fields.
+        impl From<ModelingCmd> for ModelingCmdEndpoint {
+            fn from(v: ModelingCmd) -> Self {
+                match v {#(
+                    ModelingCmd::#variants(_) => Self::#variants,
+                )*}
+            }
         }
     }
 }

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub use self::each_cmd::*;
 use crate::{self as kittycad_modeling_cmds};
 
-define_modeling_cmd_enum!(
+define_modeling_cmd_enum! {
     pub mod each_cmd {
         use std::collections::HashSet;
 
@@ -876,7 +876,7 @@ define_modeling_cmd_enum!(
         #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, ExecutionPlanFromMemory, ModelingCmdVariant)]
         pub struct SelectGet;
     }
-);
+}
 
 impl ModelingCmd {
     /// Is this command safe to run in an engine batch?


### PR DESCRIPTION
Unlike `enum ModelingCmd`, the `enum ModelingCmdEndpoint` variants never have fields. It's just a set of constants, one per modeling command endpoint/variant available.