### PR TITLE
Execution-plan-debugger: smaller default memory rows

### DIFF
--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -216,7 +216,7 @@ fn make_memory_view<'a>(
         .rev()
         .find(|addr| mem.get(&(Address::ZERO + *addr)).is_some())
         .map(|x| x + 1)
-        .unwrap_or(mem.addresses.len());
+        .unwrap_or(10);
     let rows = mem
         .addresses
         .iter()


### PR DESCRIPTION
If the EP never sets any addressable memory, the debugger would render every empty address (i.e. 1024). This is wasteful. Limit the empty rows rendered to 10 instead.