### PR TITLE
EP debugger: Start a client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "crossterm",
+ "kittycad",
  "kittycad-execution-plan",
  "kittycad-execution-plan-traits",
  "kittycad-modeling-cmds",

--- a/execution-plan-debugger/Cargo.toml
+++ b/execution-plan-debugger/Cargo.toml
@@ -10,6 +10,7 @@ description = "Debugger for KittyCAD execution plans"
 [dependencies]
 anyhow = "1"
 crossterm = "0.27.0"
+kittycad = { workspace = true }
 kittycad-execution-plan = { workspace = true }
 kittycad-execution-plan-traits = { workspace = true }
 kittycad-modeling-cmds = { workspace = true }

--- a/execution-plan-debugger/src/main.rs
+++ b/execution-plan-debugger/src/main.rs
@@ -3,6 +3,7 @@ use std::{env, io, process::exit};
 
 use anyhow::{bail, Context, Result};
 use kittycad_execution_plan::Instruction;
+use kittycad_modeling_session::Session;
 
 mod app;
 mod ui;
@@ -21,14 +22,73 @@ async fn main() {
 async fn inner_main() -> Result<()> {
     let plan = get_instrs()?;
     let mut mem = kittycad_execution_plan::Memory::default();
-    let session = None;
+    let session = client().await?;
     let (history, last_instruction) =
-        kittycad_execution_plan::execute_time_travel(&mut mem, plan.clone(), session).await;
+        kittycad_execution_plan::execute_time_travel(&mut mem, plan.clone(), Some(session)).await;
     app::run(app::Context {
         last_instruction,
         history,
         plan,
     })
+}
+
+async fn client() -> Result<Session> {
+    let Ok(kittycad_api_token) = env::var("KITTYCAD_API_TOKEN")else {
+        anyhow::bail!("You must set $KITTYCAD_API_TOKEN")
+    };
+    let kittycad_api_client = kittycad::Client::new(kittycad_api_token);
+    let session_builder = kittycad_modeling_session::SessionBuilder {
+        client: kittycad_api_client,
+        fps: Some(10),
+        unlocked_framerate: Some(false),
+        video_res_height: Some(720),
+        video_res_width: Some(1280),
+        buffer_reqs: None,
+        await_response_timeout: None,
+    };
+    match Session::start(session_builder).await {
+        Err(e) => {
+            return Err(match e {
+                kittycad::types::error::Error::InvalidRequest(s) => {
+                    anyhow::anyhow!("Request did not meet requirements {s}")
+                }
+                kittycad::types::error::Error::CommunicationError(e) => {
+                    anyhow::anyhow!(" A server error either due to the data, or with the connection: {e}")
+                }
+                kittycad::types::error::Error::RequestError(e) => anyhow::anyhow!("Could not build request: {e}"),
+                kittycad::types::error::Error::SerdeError { error, status } => {
+                    anyhow::anyhow!("Serde error (HTTP {status}): {error}")
+                }
+                kittycad::types::error::Error::InvalidResponsePayload { error, response } => {
+                    anyhow::anyhow!("Invalid response payload. Error {error}, response {response:?}")
+                }
+                kittycad::types::error::Error::Server { body, status } => {
+                    anyhow::anyhow!("Server error (HTTP {status}): {body}")
+                }
+                kittycad::types::error::Error::UnexpectedResponse(resp) => {
+                    let status = resp.status();
+                    let url = resp.url().to_owned();
+                    match resp.text().await {
+                        Ok(body) => anyhow::anyhow!(
+                            "Unexpected response from KittyCAD API.
+                        URL:{url}
+                        HTTP {status}
+                        ---Body----
+                        {body}"
+                        ),
+                        Err(e) => anyhow::anyhow!(
+                            "Unexpected response from KittyCAD API.
+                        URL:{url}
+                        HTTP {status}
+                        ---Body could not be read, the error is----
+                        {e}"
+                        ),
+                    }
+                }
+            })
+        }
+        Ok(x) => Ok(x),
+    }
 }
 
 fn get_instrs() -> Result<Vec<Instruction>> {

--- a/execution-plan/src/instruction.rs
+++ b/execution-plan/src/instruction.rs
@@ -106,7 +106,7 @@ impl Instruction {
         match self {
             Instruction::ApiRequest(req) => {
                 if let Some(session) = session {
-                    req.execute(session, mem).await?;
+                    req.execute(session, mem, events).await?;
                 } else {
                     return Err(ExecutionError::NoApiClient);
                 }


### PR DESCRIPTION
Previously the EP debugger didn't actually start a client. This worked fine while I was testing out pure, deterministic programs with no API calls. But now that I'm implementing API calls in Grackle, I need the debugger to run EPs with API calls.