### PR TITLE
EP Debugger: Scrollable view of memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +437,19 @@ checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2538,19 +2560,20 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
+checksum = "bcb12f8fbf6c62614b0d56eb352af54f6a22410c3b079eb53ee93c7b97dd31d8"
 dependencies = [
  "bitflags 2.4.1",
  "cassowary",
+ "compact_str",
  "crossterm",
  "indoc",
  "itertools 0.12.1",
  "lru",
  "paste",
  "stability",
- "strum 0.25.0",
+ "strum 0.26.1",
  "time",
  "unicode-segmentation",
  "unicode-width",
@@ -3328,6 +3351,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "structmeta"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,11 +3390,11 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 dependencies = [
- "strum_macros 0.25.3",
+ "strum_macros 0.26.1",
 ]
 
 [[package]]
@@ -3383,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/execution-plan-debugger/Cargo.toml
+++ b/execution-plan-debugger/Cargo.toml
@@ -15,7 +15,7 @@ kittycad-execution-plan = { workspace = true }
 kittycad-execution-plan-traits = { workspace = true }
 kittycad-modeling-cmds = { workspace = true }
 kittycad-modeling-session = { workspace = true }
-ratatui = { version = "0.25.0", features = ["all-widgets"] }
+ratatui = { version = "0.26.1", features = ["all-widgets"] }
 serde_json = "1.0"
 tokio = { version = "1.35.0", features = ["rt", "macros"] }
 

--- a/execution-plan-debugger/src/app.rs
+++ b/execution-plan-debugger/src/app.rs
@@ -60,7 +60,7 @@ impl TablePaneState {
 #[derive(Default, Clone, Copy, Eq, PartialEq)]
 pub enum Pane {
     #[default]
-    History,
+    Instructions,
     Addresses,
     // If you add a new enum variant, make sure to update the `fn next` below.
 }
@@ -68,22 +68,22 @@ pub enum Pane {
 impl Pane {
     pub fn next(self) -> Self {
         match self {
-            Pane::History => Self::Addresses,
-            Pane::Addresses => Self::History,
+            Pane::Instructions => Self::Addresses,
+            Pane::Addresses => Self::Instructions,
         }
     }
 }
 
-pub enum HistorySelected {
+pub enum InstructionSelected {
     Start,
     Instruction(usize),
 }
 
 impl State {
-    pub fn active_instruction(&self) -> HistorySelected {
+    pub fn active_instruction(&self) -> InstructionSelected {
         match self.instruction_pane.table.selected().unwrap() {
-            0 => HistorySelected::Start,
-            other => HistorySelected::Instruction(other - 1),
+            0 => InstructionSelected::Start,
+            other => InstructionSelected::Instruction(other - 1),
         }
     }
 }
@@ -140,19 +140,19 @@ fn main_loop(
                 match KeyPress::try_from(key.code) {
                     Ok(KeyPress::PaneNext) => state.active_pane = state.active_pane.next(),
                     Ok(KeyPress::Backwards) => match state.active_pane {
-                        Pane::History => state.instruction_pane.back(),
+                        Pane::Instructions => state.instruction_pane.back(),
                         Pane::Addresses => state.address_pane.back(),
                     },
                     Ok(KeyPress::Start) => match state.active_pane {
-                        Pane::History => state.instruction_pane.start(),
+                        Pane::Instructions => state.instruction_pane.start(),
                         Pane::Addresses => state.address_pane.start(),
                     },
                     Ok(KeyPress::End) => match state.active_pane {
-                        Pane::History => state.instruction_pane.end(),
+                        Pane::Instructions => state.instruction_pane.end(),
                         Pane::Addresses => state.address_pane.end(),
                     },
                     Ok(KeyPress::Forwards) => match state.active_pane {
-                        Pane::History => state.instruction_pane.forwards(),
+                        Pane::Instructions => state.instruction_pane.forwards(),
                         Pane::Addresses => state.address_pane.forwards(),
                     },
                     Ok(KeyPress::Quit) => return Ok(ControlFlow::Break(())),

--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -13,7 +13,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{Context, HistorySelected, Pane, State};
+use crate::app::{Context, InstructionSelected, Pane, State};
 
 pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
     // Create all widgets.
@@ -44,12 +44,12 @@ pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
             })
     };
 
-    let history_block = basic_block("History", state.active_pane == Pane::History);
+    let history_block = basic_block("History", state.active_pane == Pane::Instructions);
     let history_view = make_history_view(history_block, ctx, &instructions_with_errors);
 
     let event_block = basic_block("Events", false);
     let events = match state.active_instruction() {
-        HistorySelected::Instruction(i) => &ctx.history[i].events,
+        InstructionSelected::Instruction(i) => &ctx.history[i].events,
         _ => [].as_slice(),
     };
     let (event_view, addr_colors) = make_events_view(event_block, events);
@@ -57,7 +57,7 @@ pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
     // Render the main memory view.
     let main_mem_block = basic_block("Address Memory", state.active_pane == Pane::Addresses);
     let main_mem_view = match state.active_instruction() {
-        HistorySelected::Instruction(active_instruction) => {
+        InstructionSelected::Instruction(active_instruction) => {
             let mem = &ctx.history[active_instruction].mem;
             make_memory_view(main_mem_block, mem, addr_colors, ctx.address_size())
         }
@@ -67,7 +67,7 @@ pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
     // Render the stack view.
     let stack_view_block = basic_block("Stack Memory", false);
     let stack_mem_view = match state.active_instruction() {
-        HistorySelected::Instruction(active_instruction) => {
+        InstructionSelected::Instruction(active_instruction) => {
             let mem = &ctx.history[active_instruction].mem;
             make_stack_view(stack_view_block, &mem.stack)
         }

--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -44,8 +44,8 @@ pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
             })
     };
 
-    let history_block = basic_block("History", state.active_pane == Pane::Instructions);
-    let history_view = make_history_view(history_block, ctx, &instructions_with_errors);
+    let instruction_block = basic_block("Instructions", state.active_pane == Pane::Instructions);
+    let instruction_view = make_instruction_view(instruction_block, ctx, &instructions_with_errors);
 
     let event_block = basic_block("Events", false);
     let events = match state.active_instruction() {
@@ -54,17 +54,17 @@ pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
     };
     let (event_view, addr_colors) = make_events_view(event_block, events);
 
-    // Render the main memory view.
-    let main_mem_block = basic_block("Address Memory", state.active_pane == Pane::Addresses);
-    let main_mem_view = match state.active_instruction() {
+    // Render the addressable memory view.
+    let address_block = basic_block("Address Memory", state.active_pane == Pane::Addresses);
+    let address_view = match state.active_instruction() {
         InstructionSelected::Instruction(active_instruction) => {
             let mem = &ctx.history[active_instruction].mem;
-            make_memory_view(main_mem_block, mem, addr_colors, ctx.address_size())
+            make_address_view(address_block, mem, addr_colors, ctx.address_size())
         }
-        _ => Table::new(Vec::<Row>::new(), Vec::<Constraint>::new()).block(main_mem_block),
+        _ => Table::new(Vec::<Row>::new(), Vec::<Constraint>::new()).block(address_block),
     };
 
-    // Render the stack view.
+    // Render the stack memory view.
     let stack_view_block = basic_block("Stack Memory", false);
     let stack_mem_view = match state.active_instruction() {
         InstructionSelected::Instruction(active_instruction) => {
@@ -95,7 +95,7 @@ pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
     let body_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
-            // Left half of body, for history/instructions.
+            // Left half of body, for instructions.
             Constraint::Percentage(50),
             // Right half of body, for memory.
             Constraint::Percentage(50),
@@ -113,17 +113,17 @@ pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
     let left_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            // Top left, for history
+            // Top left, for instructions.
             Constraint::Percentage(75),
-            // Bottom left, for events
+            // Bottom left, for events.
             Constraint::Percentage(25),
         ])
         .split(body_chunks[0]);
     // Put widgets into various areas.
-    f.render_stateful_widget(history_view, left_chunks[0], &mut state.instruction_pane.table);
+    f.render_stateful_widget(instruction_view, left_chunks[0], &mut state.instruction_pane.table);
     f.render_widget(event_view, left_chunks[1]);
     f.render_widget(title, chunks[0]);
-    f.render_stateful_widget(main_mem_view, right_chunks[0], &mut state.address_pane.table);
+    f.render_stateful_widget(address_view, right_chunks[0], &mut state.address_pane.table);
     f.render_widget(stack_mem_view, right_chunks[1]);
     f.render_widget(footer, chunks[2]);
 }
@@ -218,7 +218,7 @@ fn make_events_view<'a>(block: Block<'a>, events: &[Event]) -> (Table<'a>, HashM
     (tbl, addr_colors)
 }
 
-fn make_memory_view<'a>(
+fn make_address_view<'a>(
     block: Block<'a>,
     mem: &kittycad_execution_plan::Memory,
     // num_rows: usize,
@@ -261,7 +261,7 @@ fn make_memory_view<'a>(
     .block(block)
 }
 
-fn make_history_view<'a>(block: Block<'a>, ctx: &Context, instrs_with_errors: &HashSet<usize>) -> Table<'a> {
+fn make_instruction_view<'a>(block: Block<'a>, ctx: &Context, instrs_with_errors: &HashSet<usize>) -> Table<'a> {
     let mut rows = Vec::with_capacity(ctx.plan.len() + 1);
     // Start row
     rows.push(Row::new(vec![Cell::new("0"), Cell::new("Start")]).style(Style::default().fg(GREEN)));

--- a/execution-plan/src/memory.rs
+++ b/execution-plan/src/memory.rs
@@ -215,6 +215,15 @@ impl Memory {
             .with(tabled::settings::Style::sharp())
             .to_string()
     }
+
+    /// Get the address of the last non-empty address.
+    /// If none, then all addresses are empty.
+    #[must_use]
+    pub fn last_nonempty_address(&self) -> Option<usize> {
+        self.iter()
+            .filter_map(|(i, v)| if v.is_some() { Some(i) } else { None })
+            .last()
+    }
 }
 
 fn pretty_print(p: &Primitive) -> (&'static str, String) {


### PR DESCRIPTION
https://github.com/KittyCAD/modeling-api/assets/5407457/24c8c63f-0636-4262-bec2-c793ef318d4b

As I make progress on Grackle, the programs I'm visualizing in the debugger get more and more complex. Today for the first time, I visualized VM memory with more addresses than could fit on my screen.

This means the table of memory addresses needs to be scrollable.

**User-visible changes**

- The table of memory addresses is now scrollable
- Pressing tab toggles the active view between Instructions and Memory, so you can choose which one you're scrolling. The active view is green.

**Incidental refactors**
- update ratatui to 0.26
- consistently call it "instruction view" not "history view"


