### PR TITLE
Debugger: Allow multiple related addresses

### DIFF
--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -169,13 +169,14 @@ fn make_events_view<'a>(block: Block<'a>, events: &[Event]) -> (Table<'a>, HashM
             Severity::Info => Color::default(),
             Severity::Debug => Color::DarkGray,
         };
-        let highlight_color = match event.related_address {
-            Some(addr) => {
-                let color_num = addr_colors.len();
-                addr_colors.insert(addr, HIGHLIGHT_COLORS[color_num]);
-                HIGHLIGHT_COLORS[color_num]
+        let highlight_color = if event.related_addresses.is_empty() {
+            Color::default()
+        } else {
+            let color_num = addr_colors.len();
+            for a in event.related_addresses.iter().copied() {
+                addr_colors.insert(a, HIGHLIGHT_COLORS[color_num]);
             }
-            None => Color::default(),
+            HIGHLIGHT_COLORS[color_num]
         };
         Row::new(vec![
             // Event number
@@ -188,10 +189,16 @@ fn make_events_view<'a>(block: Block<'a>, events: &[Event]) -> (Table<'a>, HashM
             )),
             // Related address
             Cell::new(Text::styled(
-                if let Some(addr) = event.related_address {
-                    addr.to_string()
-                } else {
+                if event.related_addresses.is_empty() {
                     "-".to_owned()
+                } else {
+                    event
+                        .related_addresses
+                        .iter()
+                        .map(|a| a.to_string())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                        .to_string()
                 },
                 Style::default().fg(highlight_color),
             )),

--- a/execution-plan/src/api_request.rs
+++ b/execution-plan/src/api_request.rs
@@ -40,18 +40,18 @@ impl ApiRequest {
         events.push(Event {
             text: "Reading parameters".to_owned(),
             severity: Severity::Debug,
-            related_address: Default::default(),
+            related_addresses: Default::default(),
         });
         let mut log_req = || {
             events.push(Event {
                 text: "Parameters read".to_owned(),
                 severity: Severity::Debug,
-                related_address: Default::default(),
+                related_addresses: Default::default(),
             });
             events.push(Event {
                 text: "Sending request".to_owned(),
                 severity: Severity::Info,
-                related_address: Default::default(),
+                related_addresses: Default::default(),
             });
         };
         let output = match endpoint {
@@ -107,7 +107,7 @@ impl ApiRequest {
             events.push(Event {
                 text: "Storing response".to_owned(),
                 severity: Severity::Info,
-                related_address: Some(output_address),
+                related_addresses: vec![output_address],
             });
             mem.set_composite(output_address, output);
         }

--- a/execution-plan/src/arithmetic.rs
+++ b/execution-plan/src/arithmetic.rs
@@ -89,7 +89,7 @@ macro_rules! arithmetic_body {
         $events.push({
             let mut evt = crate::events::Event::new(format!("Left operand is {l:?}"), crate::events::Severity::Info);
             if let Operand::Reference(a) = $arith.operand0 {
-                evt.related_address = Some(a);
+                evt.related_addresses = vec![a];
             }
             evt
         });
@@ -101,7 +101,7 @@ macro_rules! arithmetic_body {
         $events.push({
             let mut evt = crate::events::Event::new(format!("Right operand is {r:?}"), crate::events::Severity::Info);
             if let Operand::Reference(a) = $arith.operand1 {
-                evt.related_address = Some(a);
+                evt.related_addresses = vec![a];
             }
             evt
         });

--- a/execution-plan/src/events.rs
+++ b/execution-plan/src/events.rs
@@ -13,7 +13,7 @@ pub struct Event {
     pub severity: Severity,
     /// This event might be about a particular address.
     /// Debuggers might want to visualize this.
-    pub related_address: Option<Address>,
+    pub related_addresses: Vec<Address>,
 }
 
 impl Event {
@@ -22,7 +22,7 @@ impl Event {
         Self {
             text,
             severity,
-            related_address: None,
+            related_addresses: Default::default(),
         }
     }
 }

--- a/execution-plan/src/instruction.rs
+++ b/execution-plan/src/instruction.rs
@@ -132,7 +132,7 @@ impl Instruction {
                 events.push(Event {
                     text: "Reading value".to_owned(),
                     severity: Severity::Debug,
-                    related_address: Some(source),
+                    related_addresses: vec![source],
                 });
                 let value = mem
                     .get(&source)
@@ -143,7 +143,7 @@ impl Instruction {
                 events.push(Event {
                     text: "Writing value".to_owned(),
                     severity: Severity::Debug,
-                    related_address: Some(destination),
+                    related_addresses: vec![destination],
                 });
                 mem.set(destination, value);
             }
@@ -162,7 +162,7 @@ impl Instruction {
                         events.push(Event {
                             text: format!("Writing output to address {addr}"),
                             severity: crate::events::Severity::Info,
-                            related_address: Some(addr),
+                            related_addresses: vec![addr],
                         });
                         mem.set(addr, out);
                     }
@@ -212,14 +212,14 @@ impl Instruction {
                 events.push(Event {
                     text: format!("Property is '{member_primitive:?}'"),
                     severity: Severity::Debug,
-                    related_address: None,
+                    related_addresses: Vec::new(),
                 });
 
                 // Read the structure.
                 events.push(Event {
                     text: format!("Resolving start address {start:?}"),
                     severity: Severity::Debug,
-                    related_address: None,
+                    related_addresses: Vec::new(),
                 });
                 let start_address = match start {
                     Operand::Literal(Primitive::Address(a)) => a,
@@ -238,7 +238,7 @@ impl Instruction {
                 events.push(Event {
                     text: "Resolved start address".to_owned(),
                     severity: Severity::Debug,
-                    related_address: Some(start_address),
+                    related_addresses: vec![start_address],
                 });
                 let structure = mem
                     .get(&start_address)
@@ -256,7 +256,7 @@ impl Instruction {
                                 events.push(Event {
                                     text: format!("Property is index {i}"),
                                     severity: Severity::Info,
-                                    related_address: None,
+                                    related_addresses: Vec::new(),
                                 });
                                 (i, i.to_string())
                             } else {
@@ -269,7 +269,7 @@ impl Instruction {
                                 events.push(Event {
                                     text: format!("Property is index {i}"),
                                     severity: Severity::Info,
-                                    related_address: None,
+                                    related_addresses: Vec::new(),
                                 });
                                 (i, i.to_string())
                             } else {
@@ -291,7 +291,7 @@ impl Instruction {
                                 events.push(Event {
                                     text: format!("Property is index {i}"),
                                     severity: Severity::Info,
-                                    related_address: None,
+                                    related_addresses: Vec::new(),
                                 });
                                 (i, s.clone())
                             } else {
@@ -335,7 +335,7 @@ impl Instruction {
                 events.push(Event {
                     text: format!("Member '{member_display}' begins at addr {curr}"),
                     severity: crate::events::Severity::Info,
-                    related_address: Some(curr),
+                    related_addresses: vec![curr],
                 });
                 // Push the member onto the stack.
                 // This first address will be its length.

--- a/execution-plan/src/lib.rs
+++ b/execution-plan/src/lib.rs
@@ -101,7 +101,7 @@ pub async fn execute_time_travel(
             events.push(Event {
                 text: e.to_string(),
                 severity: events::Severity::Error,
-                related_address: None,
+                related_addresses: Vec::new(),
             });
             crashed = true;
         }


### PR DESCRIPTION
Previously we only allowed events to involve 0 or 1 addresses. But they might actually be about multiple. Some events might involve multiple addresses. 