### PR TITLE
KCVM: from_parts returns length

### DIFF
--- a/execution-plan-macros/src/derive_value.rs
+++ b/execution-plan-macros/src/derive_value.rs
@@ -45,11 +45,11 @@ fn impl_value_on_enum(
                 }
             }
 
-            fn from_parts<I>(values: &mut I) -> Result<Self, #root::MemoryError>
+            fn from_parts<I>(values: &mut I) -> Result<(Self, usize), #root::MemoryError>
             where
                 I: Iterator<Item = Option<#root::Primitive>>,
             {
-                let variant_name = String::from_parts(values)?;
+                let (variant_name, mut count) = String::from_parts(values)?;
                 match variant_name.as_str() {
                     #(#from_parts_match_each_variant)*
                     other => Err(#root::MemoryError::InvalidEnumVariant{
@@ -91,7 +91,7 @@ fn from_parts_match_arms(data: &DataEnum) -> Vec<TokenStream2> {
                         .unzip();
                     let rhs = quote_spanned! {expr.span()=>
                         #(#instantiate_fields)*
-                        Ok(Self::#variant_name{ #(#field_idents),* })
+                        Ok((Self::#variant_name{ #(#field_idents),* }, count))
                     };
                     quote_spanned! {variant.span() =>
                         stringify!(#variant_name) => {
@@ -120,7 +120,7 @@ fn from_parts_match_arms(data: &DataEnum) -> Vec<TokenStream2> {
                         .unzip();
                     let rhs = quote_spanned! {expr.span()=>
                         #(#instantiate_fields)*
-                        Ok(Self::#variant_name(#(#field_idents),* ))
+                        Ok((Self::#variant_name(#(#field_idents),*), count ))
                     };
                     quote_spanned! {expr.span() =>
                         stringify!(#variant_name) => {
@@ -137,7 +137,7 @@ fn from_parts_match_arms(data: &DataEnum) -> Vec<TokenStream2> {
                 Fields::Unit => {
                     quote_spanned! {variant.span()=>
                         stringify!(#variant_name) => {
-                            Ok(Self::#variant_name)
+                            Ok((Self::#variant_name, count))
                         }
                     }
                 }
@@ -149,12 +149,14 @@ fn from_parts_match_arms(data: &DataEnum) -> Vec<TokenStream2> {
 fn make_instantiate_field(ty: syn::Type, id: &Ident) -> TokenStream2 {
     if let Some(ub) = unbox(ty.clone()) {
         quote! {
-            let #id = Box::new(#ub::from_parts(values)?);
+            let (#id, c) = Box::new(#ub::from_parts(values)?);
+            count += c;
         }
     } else {
         let field_type = remove_generics(ty);
         quote! {
-            let #id = #field_type::from_parts(values)?;
+            let (#id, c) = #field_type::from_parts(values)?;
+            count += c;
         }
     }
 }
@@ -318,7 +320,13 @@ fn impl_value_on_struct(
     });
     let instantiate_each_field = field_names.iter().map(|(ident, span)| {
         quote_spanned! {*span=>
-            #ident: #root::Value::from_parts(values)?,
+            let (#ident, c) = #root::Value::from_parts(values)?;
+            count += c;
+        }
+    });
+    let each_field = field_names.iter().map(|(ident, span)| {
+        quote_spanned! {*span=>
+            #ident,
         }
     });
 
@@ -341,13 +349,16 @@ fn impl_value_on_struct(
                 parts
             }
 
-            fn from_parts<I>(values: &mut I) -> Result<Self, #root::MemoryError>
+            fn from_parts<I>(values: &mut I) -> Result<(Self, usize), #root::MemoryError>
             where
                 I: Iterator<Item = Option<#root::Primitive>>,
             {
-                Ok(Self {
+                let mut count = 0;
                 #(#instantiate_each_field)*
-                })
+                let slf = Self {
+                    #(#each_field)*
+                };
+                Ok((slf, count))
             }
         }
     }
@@ -384,11 +395,17 @@ fn impl_value_on_struct_unnamed_fields(
             parts.extend(self.#index.into_parts());
         }
     });
-    let instantiate_each_field = field_names.iter().map(|(_, span)| {
+    let instantiate_each_field = field_names.iter().map(|(i, span)| {
+        let ident = Ident::new(&format!("field{}", i.index), *span);
         quote_spanned! {*span=>
-            #root::Value::from_parts(values)?,
+           let (#ident, c) = #root::Value::from_parts(values)?;
+           count += c;
         }
     });
+
+    let each_field = field_names
+        .iter()
+        .map(|(i, span)| Ident::new(&format!("field{}", i.index), *span));
 
     // Handle generics in the original struct.
     // Firstly, if the original struct has defaults on its generics, e.g. Point2d<T = f32>,
@@ -409,12 +426,17 @@ fn impl_value_on_struct_unnamed_fields(
                 parts
             }
 
-            fn from_parts<I>(values: &mut I) -> Result<Self, #root::MemoryError>
+            fn from_parts<I>(values: &mut I) -> Result<(Self, usize), #root::MemoryError>
             where
                 I: Iterator<Item = Option<#root::Primitive>>,
             {
-                Ok(Self (
+                let mut count = 0;
                 #(#instantiate_each_field)*
+                Ok((
+                    Self (
+                    #(#each_field)*
+                    ),
+                    count
                 ))
             }
         }

--- a/execution-plan-traits/src/address.rs
+++ b/execution-plan-traits/src/address.rs
@@ -47,6 +47,16 @@ impl std::ops::Add<usize> for Address {
 }
 
 /// Offset the address.
+impl std::ops::Add<Address> for usize {
+    type Output = Address;
+
+    /// Offset the address.
+    fn add(self, rhs: Address) -> Self::Output {
+        rhs.offset(self)
+    }
+}
+
+/// Offset the address.
 impl std::ops::AddAssign<usize> for Address {
     /// Offset the address.
     fn add_assign(&mut self, rhs: usize) {

--- a/execution-plan-traits/src/lib.rs
+++ b/execution-plan-traits/src/lib.rs
@@ -19,7 +19,7 @@ pub trait Value: Sized {
     /// Store the value in memory.
     fn into_parts(self) -> Vec<Primitive>;
     /// Read the value from memory.
-    fn from_parts<I>(values: &mut I) -> Result<Self, MemoryError>
+    fn from_parts<I>(values: &mut I) -> Result<(Self, usize), MemoryError>
     where
         I: Iterator<Item = Option<Primitive>>;
 }
@@ -56,7 +56,7 @@ pub trait ReadMemory {
     /// Get a value from the given address.
     fn get(&self, addr: &Address) -> Option<&Primitive>;
     /// Get a value from the given starting address. Value might require multiple addresses.
-    fn get_composite<T: Value>(&self, start: Address) -> Result<T, MemoryError>;
+    fn get_composite<T: Value>(&self, start: Address) -> Result<(T, usize), MemoryError>;
     /// Remove the value on top of the stack, return it.
     fn stack_pop(&mut self) -> Result<Vec<Primitive>, MemoryError>;
     /// Return the value on top of the stack.
@@ -108,7 +108,7 @@ macro_rules! impl_value_on_primitive_ish {
                 vec![self.into()]
             }
 
-            fn from_parts<I>(values: &mut I) -> Result<Self, MemoryError>
+            fn from_parts<I>(values: &mut I) -> Result<(Self, usize), MemoryError>
             where
                 I: Iterator<Item = Option<Primitive>>,
             {
@@ -118,6 +118,7 @@ macro_rules! impl_value_on_primitive_ish {
                     .to_owned()
                     .ok_or(MemoryError::MemoryWrongSize)?
                     .try_into()
+                    .map(|prim| (prim, 1))
             }
         }
     };

--- a/execution-plan-traits/src/primitive.rs
+++ b/execution-plan-traits/src/primitive.rs
@@ -332,7 +332,7 @@ impl crate::Value for Primitive {
         vec![self]
     }
 
-    fn from_parts<I>(values: &mut I) -> Result<Self, MemoryError>
+    fn from_parts<I>(values: &mut I) -> Result<(Self, usize), MemoryError>
     where
         I: Iterator<Item = Option<Primitive>>,
     {
@@ -340,6 +340,7 @@ impl crate::Value for Primitive {
             .next()
             .and_then(|v| v.to_owned())
             .ok_or(MemoryError::MemoryWrongSize)
+            .map(|prim| (prim, 1))
     }
 }
 

--- a/execution-plan/src/api_request.rs
+++ b/execution-plan/src/api_request.rs
@@ -44,11 +44,6 @@ impl ApiRequest {
         });
         let log_req = |events: &mut EventWriter| {
             events.push(Event {
-                text: "Parameters read".to_owned(),
-                severity: Severity::Debug,
-                related_addresses: Default::default(),
-            });
-            events.push(Event {
                 text: "Sending request".to_owned(),
                 severity: Severity::Info,
                 related_addresses: Default::default(),

--- a/execution-plan/src/memory.rs
+++ b/execution-plan/src/memory.rs
@@ -63,16 +63,16 @@ impl kittycad_execution_plan_traits::ReadMemory for Memory {
 
     /// Get a value value (i.e. a value which takes up multiple addresses in memory).
     /// Its parts are stored in consecutive memory addresses starting at `start`.
-    fn get_composite<T: Value>(&self, start: Address) -> std::result::Result<T, MemoryError> {
+    fn get_composite<T: Value>(&self, start: Address) -> Result<(T, usize), MemoryError> {
         let mut values = self.addresses.iter().skip(inner(start)).cloned();
         T::from_parts(&mut values)
     }
 
-    fn stack_pop(&mut self) -> std::result::Result<Vec<Primitive>, MemoryError> {
+    fn stack_pop(&mut self) -> Result<Vec<Primitive>, MemoryError> {
         self.stack.pop()
     }
 
-    fn stack_peek(&self) -> std::result::Result<&Vec<Primitive>, MemoryError> {
+    fn stack_peek(&self) -> Result<&Vec<Primitive>, MemoryError> {
         self.stack.peek()
     }
 }


### PR DESCRIPTION
The `.from_parts()` method reads from an iterator of primitives and deserializes a value from them. Sometimes you want to know how many primitives were consumed from the iterator to make the value. Now the method also returns this number.