### PR TITLE
Execution plan: SketchGroup within VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1618,6 +1618,7 @@ dependencies = [
  "image",
  "insta",
  "kittycad",
+ "kittycad-execution-plan-macros",
  "kittycad-execution-plan-traits",
  "kittycad-modeling-cmds",
  "kittycad-modeling-session",

--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -404,5 +404,13 @@ fn describe_instruction(instruction: &Instruction) -> (std::borrow::Cow<'static,
             "Copy".into(),
             format!("copy from {source_range:?} to {destination_range:?}"),
         ),
+        Instruction::SketchGroupAddPath {
+            segment,
+            source,
+            destination,
+        } => (
+            "SGAddPath".into(),
+            format!("copy {} from {source:?} to {destination:?}", segment.segment_kind()),
+        ),
     }
 }

--- a/execution-plan-debugger/test_input.json
+++ b/execution-plan-debugger/test_input.json
@@ -185,7 +185,7 @@
         "StackPop",
         "StackPop"
       ],
-      "cmd_id": "0848c11c-50b6-4d81-903e-717b9d67171f"
+      "cmd_id": "3ce253e0-cfc3-4cb7-8e7b-dbd3a7e527ef"
     }
   },
   {
@@ -234,7 +234,7 @@
     "StackPush": {
       "data": [
         {
-          "Uuid": "0848c11c-50b6-4d81-903e-717b9d67171f"
+          "Uuid": "3ce253e0-cfc3-4cb7-8e7b-dbd3a7e527ef"
         }
       ]
     }
@@ -249,7 +249,7 @@
         "StackPop",
         "StackPop"
       ],
-      "cmd_id": "176c3eff-ef5d-46a2-9514-4ce1c787d260"
+      "cmd_id": "a21a0e8f-d569-48e3-9537-6e8029936957"
     }
   },
   {
@@ -257,14 +257,14 @@
       "endpoint": "StartPath",
       "store_response": null,
       "arguments": [],
-      "cmd_id": "c7585edd-00b6-48e7-8506-0f5becaac665"
+      "cmd_id": "d8c1ddf2-5db4-43d6-982e-31b62acde065"
     }
   },
   {
     "StackPush": {
       "data": [
         {
-          "Uuid": "c7585edd-00b6-48e7-8506-0f5becaac665"
+          "Uuid": "d8c1ddf2-5db4-43d6-982e-31b62acde065"
         }
       ]
     }
@@ -279,7 +279,7 @@
           "Address": 5
         }
       ],
-      "cmd_id": "25cbaaaf-8f51-4e7a-9824-ab8033bec7b1"
+      "cmd_id": "17cf212e-b681-4c4c-88ae-9e4f6285702d"
     }
   },
   {
@@ -287,13 +287,13 @@
       "address": 7,
       "value_parts": [
         {
-          "Uuid": "c7585edd-00b6-48e7-8506-0f5becaac665"
+          "Uuid": "d8c1ddf2-5db4-43d6-982e-31b62acde065"
         },
         {
           "String": "Plane"
         },
         {
-          "Uuid": "0848c11c-50b6-4d81-903e-717b9d67171f"
+          "Uuid": "3ce253e0-cfc3-4cb7-8e7b-dbd3a7e527ef"
         },
         {
           "String": "XY"
@@ -442,7 +442,7 @@
           "String": "Some"
         },
         {
-          "Uuid": "0848c11c-50b6-4d81-903e-717b9d67171f"
+          "Uuid": "3ce253e0-cfc3-4cb7-8e7b-dbd3a7e527ef"
         },
         {
           "NumericValue": {
@@ -539,7 +539,7 @@
       "address": 51,
       "value": {
         "NumericValue": {
-          "Float": 4.0
+          "Float": 0.0
         }
       }
     }
@@ -623,7 +623,7 @@
           "Address": 55
         }
       ],
-      "cmd_id": "a8e492bd-f3f6-4eef-9e34-aa59110bcd7b"
+      "cmd_id": "795aa93f-5af9-4a46-b942-2c418cb7bb54"
     }
   }
 ]

--- a/execution-plan/Cargo.toml
+++ b/execution-plan/Cargo.toml
@@ -11,8 +11,8 @@ description = "A DSL for composing KittyCAD API queries"
 bytes = "1.5"
 insta = "1.34.0"
 kittycad = { workspace = true }
-kittycad-execution-plan-traits = { workspace = true }
 kittycad-execution-plan-macros = { workspace = true }
+kittycad-execution-plan-traits = { workspace = true }
 kittycad-modeling-cmds = { workspace = true }
 kittycad-modeling-session = { workspace = true }
 parse-display-derive = "0.8.2"

--- a/execution-plan/Cargo.toml
+++ b/execution-plan/Cargo.toml
@@ -12,6 +12,7 @@ bytes = "1.5"
 insta = "1.34.0"
 kittycad = { workspace = true }
 kittycad-execution-plan-traits = { workspace = true }
+kittycad-execution-plan-macros = { workspace = true }
 kittycad-modeling-cmds = { workspace = true }
 kittycad-modeling-session = { workspace = true }
 parse-display-derive = "0.8.2"

--- a/execution-plan/src/instruction.rs
+++ b/execution-plan/src/instruction.rs
@@ -433,7 +433,9 @@ impl Instruction {
                 path,
                 source,
                 destination,
-            } => todo!(),
+            } => {
+                let prev_sg: SketchGroup = mem.get_in_memory(source)?.0;
+            }
         }
         Ok(())
     }

--- a/execution-plan/src/instruction.rs
+++ b/execution-plan/src/instruction.rs
@@ -1,8 +1,12 @@
-use kittycad_execution_plan_traits::{ListHeader, MemoryError, NumericPrimitive, ObjectHeader, Primitive, ReadMemory};
+use kittycad_execution_plan_traits::{
+    InMemory, ListHeader, MemoryError, NumericPrimitive, ObjectHeader, Primitive, ReadMemory, Value,
+};
+use kittycad_modeling_cmds::shared::PathSegment;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     events::{Event, EventWriter, Severity},
+    sketch_types::SketchGroup,
     Address, ApiRequest, BinaryArithmetic, Destination, ExecutionError, Memory, Operand, Result, UnaryArithmetic,
 };
 
@@ -107,6 +111,15 @@ pub enum Instruction {
         source_range: Operand,
         /// Start copying into this address.
         destination_range: Operand,
+    },
+    /// Add a path to a SketchGroup.
+    SketchGroupAddPath {
+        /// What to add to the SketchGroup.
+        path: PathSegment,
+        /// Where the SketchGroup to modify begins.
+        source: InMemory,
+        /// Where the modified SketchGroup should be written to.
+        destination: Destination,
     },
 }
 
@@ -416,6 +429,11 @@ impl Instruction {
                     mem.set(dst, val.clone());
                 }
             }
+            Instruction::SketchGroupAddPath {
+                path,
+                source,
+                destination,
+            } => todo!(),
         }
         Ok(())
     }

--- a/execution-plan/src/lib.rs
+++ b/execution-plan/src/lib.rs
@@ -25,6 +25,7 @@ pub mod api_request;
 mod arithmetic;
 mod instruction;
 mod memory;
+pub mod sketch_types;
 #[cfg(test)]
 mod tests;
 

--- a/execution-plan/src/memory.rs
+++ b/execution-plan/src/memory.rs
@@ -1,5 +1,5 @@
 use kittycad_execution_plan_traits::{
-    ListHeader, MemoryError, NumericPrimitive, ObjectHeader, Primitive, ReadMemory, Value,
+    InMemory, ListHeader, MemoryError, NumericPrimitive, ObjectHeader, Primitive, ReadMemory, Value,
 };
 
 use crate::{Address, ExecutionError};
@@ -151,6 +151,23 @@ impl Memory {
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(x)
+    }
+
+    /// Read a T value out of memory (either addressable or stack).
+    pub fn get_in_memory<T: Value>(&mut self, source: InMemory) -> Result<(T, usize), MemoryError> {
+        match source {
+            InMemory::Address(a) => self.get_composite(a),
+            InMemory::StackPop => {
+                let data = self.stack_pop()?;
+                let mut data_parts = data.iter().cloned().map(Some);
+                T::from_parts(&mut data_parts)
+            }
+            InMemory::StackPeek => {
+                let data = self.stack_peek()?;
+                let mut data_parts = data.iter().cloned().map(Some);
+                T::from_parts(&mut data_parts)
+            }
+        }
     }
 
     /// Return a nicely-formatted table of stack.

--- a/execution-plan/src/sketch_types.rs
+++ b/execution-plan/src/sketch_types.rs
@@ -1,0 +1,142 @@
+use crate::{Destination, Instruction};
+use kittycad_execution_plan_macros::ExecutionPlanValue;
+use kittycad_execution_plan_traits::{Address, Value};
+use kittycad_modeling_cmds::shared::{Point2d, Point3d, Point4d};
+use uuid::Uuid;
+
+/// A sketch group is a collection of paths.
+#[derive(Clone, ExecutionPlanValue)]
+pub struct SketchGroup {
+    // NOTE to developers
+    // Do NOT reorder these fields without updating the  _offset() methods below.
+    /// The id of the sketch group.
+    pub id: Uuid,
+    /// What the sketch is on (can be a plane or a face).
+    pub on: SketchSurface,
+    /// The position of the sketch group.
+    pub position: Point3d,
+    /// The rotation of the sketch group base plane.
+    pub rotation: Point4d,
+    /// The X, Y and Z axes of this sketch's base plane, in 3D space.
+    pub axes: Axes,
+    /// The plane id or face id of the sketch group.
+    pub entity_id: Option<Uuid>,
+    /// The base path.
+    pub path_first: BasePath,
+    /// Paths after the first path, if any.
+    pub path_rest: Vec<Path>,
+}
+
+impl SketchGroup {
+    /// Get the offset for the `id` field.
+    pub fn path_id_offset() -> usize {
+        0
+    }
+    pub fn set_base_path(&self, sketch_group: Address, start_point: Address, tag: Option<Address>) -> Vec<Instruction> {
+        let base_path_addr = sketch_group
+            + self.id.into_parts().len()
+            + self.on.into_parts().len()
+            + self.position.into_parts().len()
+            + self.rotation.into_parts().len()
+            + self.axes.into_parts().len()
+            + self.entity_id.into_parts().len()
+            + self.entity_id.into_parts().len();
+        let mut out = vec![
+            // Copy over the `from` field.
+            Instruction::Copy {
+                source: start_point,
+                destination: Destination::Address(base_path_addr),
+                length: 1,
+            },
+            // Copy over the `to` field.
+            Instruction::Copy {
+                source: start_point,
+                destination: Destination::Address(base_path_addr + self.path_first.from.into_parts().len()),
+                length: 1,
+            },
+        ];
+        if let Some(tag) = tag {
+            // Copy over the `name` field.
+            out.push(Instruction::Copy {
+                source: tag,
+                destination: Destination::Address(
+                    base_path_addr + self.path_first.from.into_parts().len() + self.path_first.to.into_parts().len(),
+                ),
+                length: 1,
+            });
+        }
+        out
+    }
+}
+
+/// The X, Y and Z axes.
+#[derive(Clone, Copy, ExecutionPlanValue)]
+pub struct Axes {
+    pub x: Point3d,
+    pub y: Point3d,
+    pub z: Point3d,
+}
+
+#[derive(Clone, ExecutionPlanValue)]
+pub struct BasePath {
+    pub from: Point2d<f64>,
+    pub to: Point2d<f64>,
+    pub name: String,
+}
+
+/// A path.
+#[derive(Clone, ExecutionPlanValue)]
+pub enum Path {
+    /// A path that goes to a point.
+    ToPoint { base: BasePath },
+    /// A arc that is tangential to the last path segment that goes to a point
+    TangentialArcTo {
+        base: BasePath,
+        /// the arc's center
+        center: Point2d,
+        /// arc's direction
+        ccw: bool,
+    },
+    /// A path that is horizontal.
+    Horizontal {
+        base: BasePath,
+        /// The x coordinate.
+        x: f64,
+    },
+    /// An angled line to.
+    AngledLineTo {
+        base: BasePath,
+        /// The x coordinate.
+        x: Option<f64>,
+        /// The y coordinate.
+        y: Option<f64>,
+    },
+    /// A base path.
+    Base { base: BasePath },
+}
+
+#[derive(Clone, Copy, ExecutionPlanValue)]
+pub enum SketchSurface {
+    Plane(Plane),
+}
+
+/// A plane.
+#[derive(Clone, Copy, ExecutionPlanValue)]
+pub struct Plane {
+    /// The id of the plane.
+    pub id: Uuid,
+    // The code for the plane either a string or custom.
+    pub value: PlaneType,
+    /// Origin of the plane.
+    pub origin: Point3d,
+    pub axes: Axes,
+}
+
+/// Type for a plane.
+#[derive(Clone, Copy, ExecutionPlanValue)]
+pub enum PlaneType {
+    XY,
+    XZ,
+    YZ,
+    Custom,
+}

--- a/execution-plan/src/snapshots/kittycad_execution_plan__tests__add_path_to_sketchgroup.snap
+++ b/execution-plan/src/snapshots/kittycad_execution_plan__tests__add_path_to_sketchgroup.snap
@@ -1,0 +1,59 @@
+---
+source: execution-plan/src/tests.rs
+expression: mem.debug_table(None)
+---
+┌──────┬──────────┬──────────────────────────────────────┐
+│ addr │ val_type │ value                                │
+├──────┼──────────┼──────────────────────────────────────┤
+│ 0    │ Uuid     │ 240f48e1-1730-4e98-b0a9-dc5f76d3582d │
+│ 1    │ String   │ Plane                                │
+│ 2    │ Uuid     │ 2076b001-8e7e-41ad-8790-adfec77616ab │
+│ 3    │ String   │ XY                                   │
+│ 4    │ Float    │ 0                                    │
+│ 5    │ Float    │ 0                                    │
+│ 6    │ Float    │ 0                                    │
+│ 7    │ Float    │ 1                                    │
+│ 8    │ Float    │ 0                                    │
+│ 9    │ Float    │ 0                                    │
+│ 10   │ Float    │ 0                                    │
+│ 11   │ Float    │ 1                                    │
+│ 12   │ Float    │ 0                                    │
+│ 13   │ Float    │ 0                                    │
+│ 14   │ Float    │ 0                                    │
+│ 15   │ Float    │ 1                                    │
+│ 16   │ Float    │ 0                                    │
+│ 17   │ Float    │ 0                                    │
+│ 18   │ Float    │ 0                                    │
+│ 19   │ Float    │ 0                                    │
+│ 20   │ Float    │ 0                                    │
+│ 21   │ Float    │ 0                                    │
+│ 22   │ Float    │ 1                                    │
+│ 23   │ Float    │ 1                                    │
+│ 24   │ Float    │ 0                                    │
+│ 25   │ Float    │ 0                                    │
+│ 26   │ Float    │ 0                                    │
+│ 27   │ Float    │ 1                                    │
+│ 28   │ Float    │ 0                                    │
+│ 29   │ Float    │ 0                                    │
+│ 30   │ Float    │ 0                                    │
+│ 31   │ Float    │ 1                                    │
+│ 32   │ String   │ None                                 │
+│ 33   │ Float    │ 0                                    │
+│ 34   │ Float    │ 0                                    │
+│ 35   │ Float    │ 20                                   │
+│ 36   │ Float    │ 30                                   │
+│ 37   │ String   │ first                                │
+│ 38   │ Uint     │ 2                                    │
+│ 39   │ String   │ ToPoint                              │
+│ 40   │ Float    │ 20                                   │
+│ 41   │ Float    │ 30                                   │
+│ 42   │ Float    │ 20                                   │
+│ 43   │ Float    │ 0                                    │
+│ 44   │ String   │ second                               │
+│ 45   │ String   │ ToPoint                              │
+│ 46   │ Float    │ 20                                   │
+│ 47   │ Float    │ 0                                    │
+│ 48   │ Float    │ 0                                    │
+│ 49   │ Float    │ 0                                    │
+│ 50   │ String   │ third                                │
+└──────┴──────────┴──────────────────────────────────────┘

--- a/execution-plan/src/tests.rs
+++ b/execution-plan/src/tests.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use insta::assert_snapshot;
 use kittycad_execution_plan_traits::{InMemory, ListHeader, ObjectHeader, Primitive, Value};
+use kittycad_modeling_cmds::shared::Point2d;
 use kittycad_modeling_cmds::ModelingCmdEndpoint as Endpoint;
 use kittycad_modeling_cmds::{
     id::ModelingCmdId,
@@ -11,6 +12,7 @@ use kittycad_modeling_cmds::{
 use kittycad_modeling_session::{Session, SessionBuilder};
 use uuid::Uuid;
 
+use crate::sketch_types::{Axes, BasePath, Plane, SketchGroup};
 use crate::{arithmetic::operator::BinaryOperation, Address};
 
 use super::*;
@@ -331,6 +333,65 @@ async fn modulo_and_power_with_reference() {
     let mut mem = Memory::default();
     execute(&mut mem, plan, None).await.expect("failed to execute plan");
     assert_eq!(mem.get(&(Address::ZERO + 1)), Some(&(-10i64).into()));
+}
+
+#[tokio::test]
+async fn add_path_to_sketch_group() {
+    let mut mem = Memory::default();
+    let axes = Axes {
+        x: Point3d { x: 1.0, y: 0.0, z: 0.0 },
+        y: Point3d { x: 0.0, y: 1.0, z: 0.0 },
+        z: Point3d { x: 0.0, y: 0.0, z: 1.0 },
+    };
+    let sg = SketchGroup {
+        id: Uuid::new_v4(),
+        on: sketch_types::SketchSurface::Plane(Plane {
+            id: Uuid::new_v4(),
+            value: sketch_types::PlaneType::XY,
+            origin: Default::default(),
+            axes,
+        }),
+        position: Default::default(),
+        rotation: Point4d {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+            w: 1.0,
+        },
+        axes,
+        entity_id: None,
+        path_first: BasePath {
+            from: Default::default(),
+            to: Point2d { x: 20.0, y: 30.0 },
+            name: "first".to_owned(),
+        },
+        path_rest: vec![crate::sketch_types::PathSegment::ToPoint {
+            base: BasePath {
+                from: Point2d { x: 20.0, y: 30.0 },
+                to: Point2d { x: 20.0, y: 0.0 },
+                name: "second".to_owned(),
+            },
+        }],
+    };
+    let instructions = vec![
+        Instruction::SetValue {
+            address: Address::ZERO,
+            value_parts: sg.into_parts(),
+        },
+        Instruction::SketchGroupAddPath {
+            segment: sketch_types::PathSegment::ToPoint {
+                base: BasePath {
+                    from: Point2d { x: 20.0, y: 0.0 },
+                    to: Point2d::default(),
+                    name: "third".to_owned(),
+                },
+            },
+            source: InMemory::Address(Address::ZERO),
+            destination: Destination::Address(Address::ZERO),
+        },
+    ];
+    execute(&mut mem, instructions, None).await.unwrap();
+    assert_snapshot!("add_path_to_sketchgroup", mem.debug_table(None));
 }
 
 #[tokio::test]

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -281,7 +281,7 @@ pub enum CameraDragInteractionType {
 
 /// A segment of a path.
 /// Paths are composed of many segments.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, ExecutionPlanValue)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum PathSegment {
     /// A straight line segment.
@@ -375,6 +375,16 @@ where
     pub x: T,
     #[allow(missing_docs)]
     pub y: T,
+}
+
+impl<T> PartialEq for Point2d<T>
+where
+    kcep::Primitive: From<T>,
+    T: kcep::Value + PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.x == other.x && self.y == other.y
+    }
 }
 
 impl<T> Point2d<T>


### PR DESCRIPTION
SketchGroup is an important type to KCL and it makes sense to build it into the VM. This **dramatically** simplifies common operations like adding a path to a SketchGroup.