### PR TITLE
KCVM: Better error messages when reading enum value from KCVM memory

### DIFF
--- a/execution-plan-macros/src/snapshots/kittycad_execution_plan_macros__derive_value__tests__enum.snap
+++ b/execution-plan-macros/src/snapshots/kittycad_execution_plan_macros__derive_value__tests__enum.snap
@@ -65,6 +65,7 @@ impl ::kittycad_execution_plan_traits::Value for FooEnum {
                 ::kittycad_execution_plan_traits::MemoryError::InvalidEnumVariant {
                     expected_type: stringify!(FooEnum).to_owned(),
                     actual: other.to_owned(),
+                    valid_variants: vec!["A", "B", "C", "D"],
                 },
             ),
         }

--- a/execution-plan-macros/src/snapshots/kittycad_execution_plan_macros__derive_value__tests__enum_with_generics.snap
+++ b/execution-plan-macros/src/snapshots/kittycad_execution_plan_macros__derive_value__tests__enum_with_generics.snap
@@ -32,6 +32,7 @@ impl ::kittycad_execution_plan_traits::Value for Segment {
                 ::kittycad_execution_plan_traits::MemoryError::InvalidEnumVariant {
                     expected_type: stringify!(Segment).to_owned(),
                     actual: other.to_owned(),
+                    valid_variants: vec!["Line"],
                 },
             ),
         }

--- a/execution-plan-traits/src/containers.rs
+++ b/execution-plan-traits/src/containers.rs
@@ -41,6 +41,7 @@ where
             other => Err(MemoryError::InvalidEnumVariant {
                 expected_type: "option".to_owned(),
                 actual: other.to_owned(),
+                valid_variants: vec![NONE, SOME],
             }),
         }
     }

--- a/execution-plan-traits/src/lib.rs
+++ b/execution-plan-traits/src/lib.rs
@@ -78,12 +78,14 @@ pub enum MemoryError {
         actual: String,
     },
     /// When trying to read an enum from memory, found a variant tag which is not valid for this enum.
-    #[error("Found an unexpected tag '{actual}' when trying to read an enum of type {expected_type} from memory")]
+    #[error("Found an unexpected tag '{actual}' when trying to read an enum of type {expected_type} from memory. Looking for one of {}", csv(.valid_variants))]
     InvalidEnumVariant {
         /// What type of enum was being read from memory.
         expected_type: String,
         /// The actual enum tag found in memory.
         actual: String,
+        /// Which values would be acceptable?
+        valid_variants: Vec<&'static str>,
     },
     /// Stack is empty
     #[error("Stack is empty")]
@@ -95,6 +97,10 @@ pub enum MemoryError {
         /// Expected to be 1, but it was something else.
         actual_length: usize,
     },
+}
+
+fn csv(v: &[&'static str]) -> String {
+    v.join(", ")
 }
 
 /// Macro to generate an `impl Value` for the given type `$subject`.


### PR DESCRIPTION
Now, if the enum variant is unexpected, the error lists the expected variants.