### PR TITLE
Debugger: Allow comments on instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,6 +1644,7 @@ dependencies = [
  "kittycad-modeling-cmds",
  "kittycad-modeling-session",
  "ratatui",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/execution-plan-debugger/Cargo.toml
+++ b/execution-plan-debugger/Cargo.toml
@@ -16,6 +16,7 @@ kittycad-execution-plan-traits = { workspace = true }
 kittycad-modeling-cmds = { workspace = true }
 kittycad-modeling-session = { workspace = true }
 ratatui = { version = "0.26.1", features = ["all-widgets"] }
+serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1.35.0", features = ["rt", "macros"] }
 

--- a/execution-plan-debugger/src/app.rs
+++ b/execution-plan-debugger/src/app.rs
@@ -1,4 +1,4 @@
-use std::{io::stderr, ops::ControlFlow, time::Duration};
+use std::{collections::HashMap, io::stderr, ops::ControlFlow, time::Duration};
 
 use kittycad_execution_plan::Instruction;
 use ratatui::{backend::CrosstermBackend, widgets::TableState, Terminal};
@@ -10,6 +10,7 @@ pub struct Context {
     pub history: Vec<kittycad_execution_plan::ExecutionState>,
     pub last_instruction: usize,
     pub plan: Vec<Instruction>,
+    pub comments: HashMap<usize, String>,
 }
 impl Context {
     /// How many addresses should be shown?

--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -49,10 +49,22 @@ pub fn ui(f: &mut Frame, ctx: &Context, state: &mut State) {
 
     let event_block = basic_block("Events", false);
     let events = match state.active_instruction() {
-        InstructionSelected::Instruction(i) => &ctx.history[i].events,
-        _ => [].as_slice(),
+        InstructionSelected::Start => Vec::new(),
+        InstructionSelected::Instruction(instr) => match ctx.comments.get(&instr) {
+            Some(comment) => {
+                let mut v = Vec::with_capacity(1 + ctx.history[instr].events.len());
+                v.push(Event {
+                    text: comment.to_owned(),
+                    severity: Severity::Info,
+                    related_addresses: Default::default(),
+                });
+                v.extend(ctx.history[instr].events.clone());
+                v
+            }
+            None => ctx.history[instr].events.to_vec(),
+        },
     };
-    let (event_view, addr_colors) = make_events_view(event_block, events);
+    let (event_view, addr_colors) = make_events_view(event_block, &events);
 
     // Render the addressable memory view.
     let address_block = basic_block("Address Memory", state.active_pane == Pane::Addresses);

--- a/execution-plan-debugger/test_input.json
+++ b/execution-plan-debugger/test_input.json
@@ -1,4 +1,9 @@
-[
+{
+"comments": {
+  "0": "foo",
+  "1": "bar"
+},
+"instructions":  [
   {
     "SetPrimitive": {
       "address": 0,
@@ -1183,3 +1188,4 @@
     }
   }
 ]
+}


### PR DESCRIPTION
Closes https://github.com/KittyCAD/modeling-api/issues/205

The input JSON has been modified. Previously it accepted a Vec<Instruction>, now that is just one field of a JSON object.

The other field is a map from instruction indices to string comments. These comments show up in the debugger as events at the start of that instruction.

Grackle will be updated to set these comments, to make it easier to read Grackle traces in this debugger.