### PR TITLE
KCVM: Queue API calls to run in batch

### DIFF
--- a/execution-plan-debugger/src/ui.rs
+++ b/execution-plan-debugger/src/ui.rs
@@ -435,6 +435,5 @@ fn describe_instruction(instruction: &Instruction) -> (std::borrow::Cow<'static,
             ("SGGetLastPoint".into(), format!("source {source} dst={destination}"))
         }
         Instruction::NoOp { comment } => ("No op".into(), comment.to_owned()),
-        Instruction::ApiBatch(reqs) => ("API batch".into(), format!("{reqs:?}")),
     }
 }

--- a/execution-plan/src/api_request.rs
+++ b/execution-plan/src/api_request.rs
@@ -53,47 +53,47 @@ impl ApiRequest {
             Endpoint::StartPath => {
                 let cmd = each_cmd::StartPath::from_memory(&mut arguments, mem, events)?;
                 log_req(events);
-                session.run_command(cmd_id, cmd).await?
+                session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
             }
             Endpoint::MovePathPen => {
                 let cmd = each_cmd::MovePathPen::from_memory(&mut arguments, mem, events)?;
                 log_req(events);
-                session.run_command(cmd_id, cmd).await?
+                session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
             }
             Endpoint::ExtendPath => {
                 let cmd = each_cmd::ExtendPath::from_memory(&mut arguments, mem, events)?;
                 log_req(events);
-                session.run_command(cmd_id, cmd).await?
+                session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
             }
             Endpoint::ClosePath => {
                 let cmd = each_cmd::ClosePath::from_memory(&mut arguments, mem, events)?;
                 log_req(events);
-                session.run_command(cmd_id, cmd).await?
+                session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
             }
             Endpoint::Extrude => {
                 let cmd = each_cmd::Extrude::from_memory(&mut arguments, mem, events)?;
                 log_req(events);
-                session.run_command(cmd_id, cmd).await?
+                session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
             }
             Endpoint::TakeSnapshot => {
                 let cmd = each_cmd::TakeSnapshot::from_memory(&mut arguments, mem, events)?;
                 log_req(events);
-                session.run_command(cmd_id, cmd).await?
+                session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
             }
             Endpoint::MakePlane => {
                 let cmd = each_cmd::MakePlane::from_memory(&mut arguments, mem, events)?;
                 log_req(events);
-                session.run_command(cmd_id, cmd).await?
+                session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
             }
             Endpoint::EnableSketchMode => {
                 let cmd = each_cmd::EnableSketchMode::from_memory(&mut arguments, mem, events)?;
                 log_req(events);
-                session.run_command(cmd_id, cmd).await?
+                session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
             }
             Endpoint::SketchModeEnable => {
                 let cmd = each_cmd::SketchModeEnable::from_memory(&mut arguments, mem, events)?;
                 log_req(events);
-                session.run_command(cmd_id, cmd).await?
+                session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
             }
             other => panic!("Haven't implemented endpoint {other:?} yet"),
         };

--- a/execution-plan/src/api_request.rs
+++ b/execution-plan/src/api_request.rs
@@ -1,14 +1,9 @@
 //! Instruction for running KittyCAD API requests.
 
-use std::collections::HashMap;
-
 use crate::events::{Event, Severity};
 use crate::Result;
 use crate::{events::EventWriter, memory::Memory};
 use kittycad_execution_plan_traits::{Address, FromMemory, InMemory};
-use kittycad_modeling_cmds::ok_response::OkModelingCmdResponse;
-use kittycad_modeling_cmds::websocket::{ModelingBatch, ModelingCmdReq};
-use kittycad_modeling_cmds::ModelingCmd;
 use kittycad_modeling_cmds::{each_cmd, id::ModelingCmdId, ModelingCmdEndpoint as Endpoint};
 use kittycad_modeling_session::Session as ModelingSession;
 use serde::{Deserialize, Serialize};
@@ -104,90 +99,13 @@ impl ApiRequest {
         };
         // Write out to memory.
         if let Some(output_address) = store_response {
-            output_response(events, output_address, output, mem);
+            events.push(Event {
+                text: "Storing response".to_owned(),
+                severity: Severity::Info,
+                related_addresses: vec![output_address],
+            });
+            mem.set_composite(output_address, output);
         }
         Ok(())
     }
-}
-
-/// Store the given response in the given address.
-fn output_response(events: &mut EventWriter, dst: Address, response: OkModelingCmdResponse, mem: &mut Memory) {
-    events.push(Event {
-        text: "Storing response".to_owned(),
-        severity: Severity::Info,
-        related_addresses: vec![dst],
-    });
-    mem.set_composite(dst, response);
-}
-
-pub(crate) async fn execute_batch(
-    reqs: Vec<ApiRequest>,
-    session: &mut ModelingSession,
-    mem: &mut Memory,
-    events: &mut EventWriter,
-) -> Result<()> {
-    // We will need to look up responses in this hash table later.
-    let reqs_by_id: HashMap<_, _> = reqs.iter().map(|req| (req.cmd_id, req.clone())).collect();
-
-    // Collect the individual requests into a batch.
-    let batch = reqs
-        .iter()
-        .map(|req| {
-            let cmd_id = req.cmd_id;
-            let mut arguments = req.arguments.clone().into_iter();
-            let cmd = match &req.endpoint {
-                Endpoint::StartPath => {
-                    let cmd = each_cmd::StartPath::from_memory(&mut arguments, mem, events)?;
-                    ModelingCmd::from(cmd)
-                }
-                Endpoint::MovePathPen => {
-                    let cmd = each_cmd::MovePathPen::from_memory(&mut arguments, mem, events)?;
-                    ModelingCmd::from(cmd)
-                }
-                Endpoint::ExtendPath => {
-                    let cmd = each_cmd::ExtendPath::from_memory(&mut arguments, mem, events)?;
-                    ModelingCmd::from(cmd)
-                }
-                Endpoint::ClosePath => {
-                    let cmd = each_cmd::ClosePath::from_memory(&mut arguments, mem, events)?;
-                    ModelingCmd::from(cmd)
-                }
-                Endpoint::Extrude => {
-                    let cmd = each_cmd::Extrude::from_memory(&mut arguments, mem, events)?;
-                    ModelingCmd::from(cmd)
-                }
-                Endpoint::TakeSnapshot => {
-                    let cmd = each_cmd::TakeSnapshot::from_memory(&mut arguments, mem, events)?;
-                    ModelingCmd::from(cmd)
-                }
-                Endpoint::MakePlane => {
-                    let cmd = each_cmd::MakePlane::from_memory(&mut arguments, mem, events)?;
-                    ModelingCmd::from(cmd)
-                }
-                Endpoint::EnableSketchMode => {
-                    let cmd = each_cmd::EnableSketchMode::from_memory(&mut arguments, mem, events)?;
-                    ModelingCmd::from(cmd)
-                }
-                Endpoint::SketchModeEnable => {
-                    let cmd = each_cmd::SketchModeEnable::from_memory(&mut arguments, mem, events)?;
-                    ModelingCmd::from(cmd)
-                }
-                other => panic!("Haven't implemented endpoint {other:?} yet"),
-            };
-            Ok(ModelingCmdReq { cmd, cmd_id })
-        })
-        .collect::<Result<Vec<_>>>()
-        .map(|requests| ModelingBatch { requests })?;
-
-    // Send the batch.
-    let resps = session.run_batch(batch).await?;
-
-    // For each response, write it to the given output address.
-    for resp in resps {
-        let store_response = reqs_by_id.get(&resp.cmd_id).unwrap().store_response;
-        if let Some(output_address) = store_response {
-            output_response(events, output_address, resp.response, mem);
-        }
-    }
-    Ok(())
 }

--- a/execution-plan/src/instruction.rs
+++ b/execution-plan/src/instruction.rs
@@ -1,7 +1,7 @@
 use kittycad_execution_plan_traits::{
     InMemory, ListHeader, MemoryError, NumericPrimitive, ObjectHeader, Primitive, ReadMemory, Value,
 };
-use kittycad_modeling_cmds::shared::Point2d;
+use kittycad_modeling_cmds::{shared::Point2d, websocket::ModelingBatch};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -173,12 +173,13 @@ impl Instruction {
         mem: &mut Memory,
         session: &mut Option<kittycad_modeling_session::Session>,
         events: &mut EventWriter,
+        batch_queue: &mut ModelingBatch,
     ) -> Result<()> {
         match self {
             Instruction::NoOp { comment: _ } => {}
             Instruction::ApiRequest(req) => {
                 if let Some(session) = session {
-                    req.execute(session, mem, events).await?;
+                    req.execute(session, mem, events, batch_queue).await?;
                 } else {
                     return Err(ExecutionError::NoApiClient);
                 }

--- a/execution-plan/src/instruction.rs
+++ b/execution-plan/src/instruction.rs
@@ -15,8 +15,6 @@ use crate::{
 pub enum Instruction {
     /// Call the KittyCAD API.
     ApiRequest(ApiRequest),
-    /// Batch multiple API requests.
-    ApiBatch(Vec<ApiRequest>),
     /// Set a primitive to a memory address.
     SetPrimitive {
         /// Which memory address to set.
@@ -178,13 +176,6 @@ impl Instruction {
     ) -> Result<()> {
         match self {
             Instruction::NoOp { comment: _ } => {}
-            Instruction::ApiBatch(reqs) => {
-                if let Some(session) = session {
-                    crate::api_request::execute_batch(reqs, session, mem, events).await?;
-                } else {
-                    return Err(ExecutionError::NoApiClient);
-                }
-            }
             Instruction::ApiRequest(req) => {
                 if let Some(session) = session {
                     req.execute(session, mem, events).await?;

--- a/execution-plan/src/tests.rs
+++ b/execution-plan/src/tests.rs
@@ -748,45 +748,43 @@ async fn api_call_draw_cube() {
                 arguments: vec![InMemory::Address(path_id_addr), InMemory::StackPop],
                 cmd_id: new_id(),
             }),
-            Instruction::ApiBatch(vec![
-                ApiRequest {
-                    endpoint: Endpoint::ExtendPath,
-                    store_response: None,
-                    arguments: vec![path_id_addr.into(), segment_addrs[0].into()],
-                    cmd_id: new_id(),
-                },
-                ApiRequest {
-                    endpoint: Endpoint::ExtendPath,
-                    store_response: None,
-                    arguments: vec![path_id_addr.into(), segment_addrs[1].into()],
-                    cmd_id: new_id(),
-                },
-                ApiRequest {
-                    endpoint: Endpoint::ExtendPath,
-                    store_response: None,
-                    arguments: vec![path_id_addr.into(), segment_addrs[2].into()],
-                    cmd_id: new_id(),
-                },
-                ApiRequest {
-                    endpoint: Endpoint::ExtendPath,
-                    store_response: None,
-                    arguments: vec![path_id_addr.into(), segment_addrs[3].into()],
-                    cmd_id: new_id(),
-                },
-                ApiRequest {
-                    endpoint: Endpoint::ClosePath,
-                    store_response: None,
-                    arguments: vec![path_id_addr.into()],
-                    cmd_id: new_id(),
-                },
-                // Turn square into cube
-                ApiRequest {
-                    endpoint: Endpoint::Extrude,
-                    store_response: None,
-                    arguments: vec![path_id_addr.into(), cube_height_addr.into(), cap_addr.into()],
-                    cmd_id: new_id(),
-                },
-            ]),
+            Instruction::ApiRequest(ApiRequest {
+                endpoint: Endpoint::ExtendPath,
+                store_response: None,
+                arguments: vec![path_id_addr.into(), segment_addrs[0].into()],
+                cmd_id: new_id(),
+            }),
+            Instruction::ApiRequest(ApiRequest {
+                endpoint: Endpoint::ExtendPath,
+                store_response: None,
+                arguments: vec![path_id_addr.into(), segment_addrs[1].into()],
+                cmd_id: new_id(),
+            }),
+            Instruction::ApiRequest(ApiRequest {
+                endpoint: Endpoint::ExtendPath,
+                store_response: None,
+                arguments: vec![path_id_addr.into(), segment_addrs[2].into()],
+                cmd_id: new_id(),
+            }),
+            Instruction::ApiRequest(ApiRequest {
+                endpoint: Endpoint::ExtendPath,
+                store_response: None,
+                arguments: vec![path_id_addr.into(), segment_addrs[3].into()],
+                cmd_id: new_id(),
+            }),
+            Instruction::ApiRequest(ApiRequest {
+                endpoint: Endpoint::ClosePath,
+                store_response: None,
+                arguments: vec![path_id_addr.into()],
+                cmd_id: new_id(),
+            }),
+            // Turn square into cube
+            Instruction::ApiRequest(ApiRequest {
+                endpoint: Endpoint::Extrude,
+                store_response: None,
+                arguments: vec![path_id_addr.into(), cube_height_addr.into(), cap_addr.into()],
+                cmd_id: new_id(),
+            }),
             Instruction::ApiRequest(ApiRequest {
                 endpoint: Endpoint::TakeSnapshot,
                 store_response: Some(output_addr),

--- a/modeling-cmds/src/websocket.rs
+++ b/modeling-cmds/src/websocket.rs
@@ -93,7 +93,7 @@ pub enum WebSocketRequest {
 }
 
 /// A sequence of modeling requests. If any request fails, following requests will not be tried.
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Default)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "snake_case")]
 pub struct ModelingBatch {
     /// A sequence of modeling requests. If any request fails, following requests will not be tried.

--- a/modeling-cmds/src/websocket.rs
+++ b/modeling-cmds/src/websocket.rs
@@ -93,11 +93,23 @@ pub enum WebSocketRequest {
 }
 
 /// A sequence of modeling requests. If any request fails, following requests will not be tried.
-#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Default)]
 #[serde(rename_all = "snake_case")]
 pub struct ModelingBatch {
     /// A sequence of modeling requests. If any request fails, following requests will not be tried.
     pub requests: Vec<ModelingCmdReq>,
+}
+
+impl ModelingBatch {
+    /// Add a new modeling command to the end of this batch.
+    pub fn push(&mut self, req: ModelingCmdReq) {
+        self.requests.push(req);
+    }
+
+    /// Are there any requests in the batch?
+    pub fn is_empty(&self) -> bool {
+        self.requests.is_empty()
+    }
 }
 
 /// Representation of an ICE server used for STUN/TURN

--- a/modeling-session/examples/cube_png.rs
+++ b/modeling-session/examples/cube_png.rs
@@ -10,7 +10,7 @@ use kittycad_modeling_cmds::{
     length_unit::LengthUnit,
     ok_response::OkModelingCmdResponse,
     shared::{PathSegment, Point3d},
-    ClosePath, ExtendPath, Extrude, MovePathPen, StartPath, TakeSnapshot,
+    ClosePath, ExtendPath, Extrude, ModelingCmd, MovePathPen, StartPath, TakeSnapshot,
 };
 use kittycad_modeling_session::{Session, SessionBuilder};
 use uuid::Uuid;
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     let path_id = Uuid::new_v4();
     let path = path_id.into();
     session
-        .run_command(path, StartPath {})
+        .run_command(path, ModelingCmd::StartPath(StartPath {}))
         .await
         .context("could not create path")?;
 
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
         z: -CUBE_WIDTH,
     };
     session
-        .run_command(random_id(), MovePathPen { path, to: start })
+        .run_command(random_id(), MovePathPen { path, to: start }.into())
         .await
         .context("could not move path pen to start")?;
 
@@ -89,14 +89,15 @@ async fn main() -> Result<()> {
                         end: point,
                         relative: false,
                     },
-                },
+                }
+                .into(),
             )
             .await
             .context("could not draw square")?;
     }
     // Extrude the square into a cube.
     session
-        .run_command(random_id(), ClosePath { path_id })
+        .run_command(random_id(), ModelingCmd::ClosePath(ClosePath { path_id }))
         .await
         .context("could not close square path")?;
     session
@@ -106,7 +107,8 @@ async fn main() -> Result<()> {
                 cap: true,
                 distance: CUBE_WIDTH * 2.0,
                 target: path,
-            },
+            }
+            .into(),
         )
         .await
         .context("could not extrude square into cube")?;
@@ -116,7 +118,8 @@ async fn main() -> Result<()> {
             random_id(),
             TakeSnapshot {
                 format: kittycad_modeling_cmds::ImageFormat::Png,
-            },
+            }
+            .into(),
         )
         .await
         .context("could not get PNG snapshot")?;

--- a/modeling-session/examples/cube_png_batch.rs
+++ b/modeling-session/examples/cube_png_batch.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
     let path_id = Uuid::new_v4();
     let path = path_id.into();
     session
-        .run_command(path, StartPath {})
+        .run_command(path, StartPath {}.into())
         .await
         .context("could not create path")?;
 
@@ -112,7 +112,8 @@ async fn main() -> Result<()> {
             random_id(),
             TakeSnapshot {
                 format: kittycad_modeling_cmds::ImageFormat::Png,
-            },
+            }
+            .into(),
         )
         .await
         .context("could not get PNG snapshot")?;

--- a/modeling-session/src/lib.rs
+++ b/modeling-session/src/lib.rs
@@ -107,38 +107,15 @@ impl Session {
     }
 
     /// Run a batch of commands at once.
-    pub async fn run_batch(&mut self, batch: ModelingBatch) -> Result<Vec<BatchResponse>, RunCommandError> {
-        let req_ids: Vec<_> = batch.requests.iter().map(|req| req.cmd_id).collect();
-
-        // Send all commands.
+    pub async fn run_batch(&mut self, batch: ModelingBatch) -> Result<(), RunCommandError> {
         let (tx, rx) = oneshot::channel();
         self.actor_tx
             .send(actor::Request::SendModelingBatch(batch, tx))
             .await
             .map_err(|_| RunCommandError::ActorFailed)?;
         rx.await.map_err(|_| RunCommandError::ActorFailed)??;
-
-        // Get all responses.
-        let mut resps = Vec::new();
-        for cmd_id in req_ids {
-            let (tx, rx) = oneshot::channel();
-            self.actor_tx
-                .send(actor::Request::GetResponse(cmd_id, tx))
-                .await
-                .map_err(|_| RunCommandError::ActorFailed)?;
-            let response = rx.await.map_err(|_| RunCommandError::ActorFailed)??;
-            resps.push(BatchResponse { response, cmd_id });
-        }
-        Ok(resps)
+        Ok(())
     }
-}
-
-/// Response to a batched request.
-pub struct BatchResponse {
-    /// Which request is this response for?
-    pub cmd_id: ModelingCmdId,
-    /// The response to the command.
-    pub response: OkModelingCmdResponse,
 }
 
 /// Errors from running a modeling command.

--- a/modeling-session/src/lib.rs
+++ b/modeling-session/src/lib.rs
@@ -79,18 +79,14 @@ impl Session {
     }
 
     /// Send a modeling command and wait for its response.
-    pub async fn run_command<Cmd>(
+    pub async fn run_command(
         &mut self,
         cmd_id: ModelingCmdId,
-        cmd: Cmd,
-    ) -> Result<OkModelingCmdResponse, RunCommandError>
-    where
-        Cmd: kittycad_modeling_cmds::ModelingCmdVariant,
-    {
+        cmd: ModelingCmd,
+    ) -> Result<OkModelingCmdResponse, RunCommandError> {
         // All messages to the KittyCAD Modeling API will be sent over the WebSocket as Text.
         // The text will contain JSON representing a `ModelingCmdReq`.
         // This takes in a command and its ID, and makes a WebSocket message containing that command.
-        let cmd = ModelingCmd::from(cmd);
         let (tx, rx) = oneshot::channel();
         self.actor_tx
             .send(actor::Request::SendModelingCmd(ModelingCmdReq { cmd, cmd_id }, tx))


### PR DESCRIPTION
This reverts my previous PR https://github.com/KittyCAD/modeling-api/pull/219 which added a dedicated API Batch instruction.

Instead, when the KCVM would execute an API call instruction, it first checks. Does that API call store its output? If not, then it doesn't execute immediately. It just evaluates the arguments and stores them in a queue of API commands. It eventually executes this queue of API commands, all in one batch. This happens when either

1. A non-batchable API call has to be executed (the batch queue is cleared first)
2. The program is about to end

This successfully batches 8 API calls in the "draw cube" unit test. Here's the event output from that test. Note the events like "Adding Extrude to batch queue", and "Running 8 batched API calls".


```
Event {
    text: "Adding StartPath to batch queue",
    severity: Info,
    related_addresses: [],
},
Event {
    text: "Read 'path'",
    severity: Debug,
    related_addresses: [
        Addr0,
    ],
},
Event {
    text: "Stack pop to read 'to'",
    severity: Debug,
    related_addresses: [],
},
Event {
    text: "Adding MovePathPen to batch queue",
    severity: Info,
    related_addresses: [],
},
Event {
    text: "Read 'path'",
    severity: Debug,
    related_addresses: [
        Addr0,
    ],
},
Event {
    text: "Read 'segment'",
    severity: Debug,
    related_addresses: [
        Addr4,
        Addr5,
        Addr6,
        Addr7,
        Addr8,
    ],
},
Event {
    text: "Adding ExtendPath to batch queue",
    severity: Info,
    related_addresses: [],
},
Event {
    text: "Read 'path'",
    severity: Debug,
    related_addresses: [
        Addr0,
    ],
},
Event {
    text: "Read 'segment'",
    severity: Debug,
    related_addresses: [
        Addr9,
        Addr10,
        Addr11,
        Addr12,
        Addr13,
    ],
},
Event {
    text: "Adding ExtendPath to batch queue",
    severity: Info,
    related_addresses: [],
},
Event {
    text: "Read 'path'",
    severity: Debug,
    related_addresses: [
        Addr0,
    ],
},
Event {
    text: "Read 'segment'",
    severity: Debug,
    related_addresses: [
        Addr14,
        Addr15,
        Addr16,
        Addr17,
        Addr18,
    ],
},
Event {
    text: "Adding ExtendPath to batch queue",
    severity: Info,
    related_addresses: [],
},
Event {
    text: "Read 'path'",
    severity: Debug,
    related_addresses: [
        Addr0,
    ],
},
Event {
    text: "Read 'segment'",
    severity: Debug,
    related_addresses: [
        Addr19,
        Addr20,
        Addr21,
        Addr22,
        Addr23,
    ],
},
Event {
    text: "Adding ExtendPath to batch queue",
    severity: Info,
    related_addresses: [],
},
Event {
    text: "Read 'path_id'",
    severity: Debug,
    related_addresses: [
        Addr0,
    ],
},
Event {
    text: "Adding ClosePath to batch queue",
    severity: Info,
    related_addresses: [],
},
Event {
    text: "Read 'target'",
    severity: Debug,
    related_addresses: [
        Addr0,
    ],
},
Event {
    text: "Read 'distance'",
    severity: Debug,
    related_addresses: [
        Addr1,
    ],
},
Event {
    text: "Read 'cap'",
    severity: Debug,
    related_addresses: [
        Addr2,
    ],
},
Event {
    text: "Adding Extrude to batch queue",
    severity: Info,
    related_addresses: [],
},
Event {
    text: "Running 8 batched API calls",
    severity: Info,
    related_addresses: [],
},
Event {
    text: "Reading parameters",
    severity: Debug,
    related_addresses: [],
},
Event {
    text: "Read 'format'",
    severity: Debug,
    related_addresses: [
        Addr3,
    ],
},
Event {
    text: "Sending request",
    severity: Info,
    related_addresses: [],
},
Event {
    text: "Storing response",
    severity: Info,
    related_addresses: [
        Addr99,
    ],
},
```