### PR TITLE
Fix semver

### DIFF
--- a/modeling-cmds-macros/src/modeling_cmd_enum.rs
+++ b/modeling-cmds-macros/src/modeling_cmd_enum.rs
@@ -68,6 +68,8 @@ pub(crate) fn generate(input: ItemMod) -> TokenStream {
         )*}
         /// Each modeling command (no parameters or fields).
         #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, ::parse_display::Display)]
+        #[serde(rename_all = "snake_case")]
+        #[cfg_attr(not(unstable_exhaustive), non_exhaustive)]
         pub enum ModelingCmdEndpoint{#(
             #[doc = #docs]
             #variants,


### PR DESCRIPTION
The `ModelingCmdEndpoint` enum needs the same `#[non_exhaustive]` attribute that `ModelingCmd` enum has.

Also while I was here, I noticed it didn't have serde snake_case.