### PR TITLE
Remove Export::source_unit

### DIFF
--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -201,8 +201,6 @@ define_modeling_cmd_enum! {
         pub struct Export {
             /// IDs of the entities to be exported. If this is empty, then all entities are exported.
             pub entity_ids: Vec<Uuid>,
-            /// Select the unit interpretation of exported objects.
-            pub source_unit: units::UnitLength,
             /// The file format to export to.
             pub format: OutputFormat,
         }


### PR DESCRIPTION
Engine units are now standardised to millimetres. The units used in the exported file continue to be determined by the export format configuration.