### PR TITLE
OkModelingCmdResponse should be non-exhaustive

### DIFF
--- a/modeling-cmds-macros/src/ok_modeling_cmd_response_enum.rs
+++ b/modeling-cmds-macros/src/ok_modeling_cmd_response_enum.rs
@@ -36,6 +36,7 @@ pub(crate) fn generate(input: ItemMod) -> TokenStream {
         /// This can be one of several types of responses, depending on the command.
         #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue)]
         #[serde(rename_all = "snake_case", tag = "type", content = "data")]
+        #[cfg_attr(not(unstable_exhaustive), non_exhaustive)]
         pub enum OkModelingCmdResponse {
             /// An empty response, used for any command that does not explicitly have a response
             /// defined here.


### PR DESCRIPTION
Users of the modeling-cmds library shouldn't exhaustively match over OkModelingCmdResponse as Zoo could add new variants at any point without bumping semver.

Users can opt into exhaustiveness via the `unstable_exhaustive` feature.