### PR TITLE
Scriptable releases of modeling-cmds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,10 +95,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.80"
+name = "anstream"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 dependencies = [
  "backtrace",
 ]
@@ -282,6 +330,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "bumper"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "semver",
+ "serde",
+ "toml_edit 0.22.9",
+]
+
+[[package]]
 name = "bytecount"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +456,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
 name = "color-eyre"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +527,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -1248,6 +1353,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -3129,9 +3240,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
@@ -3392,6 +3503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "structmeta"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3438,7 +3555,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3451,7 +3568,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3564,7 +3681,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c138f99377e5d653a371cdad263615634cfc8467685dfe8e73e2b8e98f44b17"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -3765,7 +3882,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.21.0",
 ]
 
 [[package]]
@@ -3787,7 +3904,18 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.30",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+dependencies = [
+ "indexmap 2.1.0",
+ "toml_datetime",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -4036,6 +4164,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -4650,6 +4784,15 @@ name = "winnow"
 version = "0.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b5c3db89721d50d0e2a673f5043fc4722f76dcc352d7b1ab8b8288bed4ed2c5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "bumper",
     "execution-plan",
     "execution-plan-debugger",
     "execution-plan-macros",

--- a/bumper/Cargo.toml
+++ b/bumper/Cargo.toml
@@ -1,0 +1,21 @@
+
+[package]
+name = "bumper"
+version = "0.1.0"
+edition = "2021"
+repository = "https://github.com/KittyCAD/modeling-api"
+rust-version = "1.76"
+description = "Bumps versions in Cargo.toml"
+publish = false
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.81"
+clap = { version = "4.5.3", features = ["derive"] }
+semver = "1.0.22"
+serde = "1.0.197"
+toml_edit = "0.22.9"
+
+[lints]
+workspace = true
+

--- a/bumper/src/main.rs
+++ b/bumper/src/main.rs
@@ -1,0 +1,79 @@
+//! Bumps versions in Cargo.toml.
+use anyhow::Context;
+use clap::Parser;
+use toml_edit::{value, DocumentMut};
+
+fn main() {
+    let args = Args::parse();
+    if let Err(e) = inner_main(args) {
+        eprintln!("{e}");
+        std::process::exit(1);
+    }
+}
+
+fn inner_main(args: Args) -> anyhow::Result<()> {
+    let cargo_dot_toml = std::fs::read(&args.manifest_path).context("Could not read chosen Cargo.toml")?;
+    let cargo_dot_toml = String::from_utf8(cargo_dot_toml).context("Invalid UTF-8 in chosen Cargo.toml")?;
+    let mut doc = cargo_dot_toml
+        .parse::<DocumentMut>()
+        .context("Invalid TOML in Cargo.toml")?;
+    update_semver(args.bump, &mut doc).context("Could not bump semver")?;
+    std::fs::write(args.manifest_path, doc.to_string()).context("Could not write updated Cargo.toml")?;
+    Ok(())
+}
+
+/// Update the given TOML document (for a Cargo.toml file) by bumping its `version` field.
+/// What kind of bump (major, minor, patch) is given by the `bump` argument.
+fn update_semver(bump: SemverBump, doc: &mut DocumentMut) -> anyhow::Result<()> {
+    let current_version = doc["package"]["version"]
+        .to_string()
+        // Clean quotations and whitespace.
+        .replace([' ', '"'], "");
+
+    let current_version = semver::Version::parse(&current_version).context("Could not parse semver version")?;
+    println!("Current version is {current_version}");
+
+    // Get the next version.
+    let mut next_version = current_version;
+    match bump {
+        SemverBump::Major => next_version.major += 1,
+        SemverBump::Minor => next_version.minor += 1,
+        SemverBump::Patch => next_version.patch += 1,
+    };
+    println!("Bumping to {next_version}");
+
+    // Update the Cargo.toml
+    doc["package"]["version"] = value(next_version.to_string());
+    Ok(())
+}
+
+/// Bumps versions in Cargo.toml
+#[derive(Parser, Debug)]
+struct Args {
+    /// Which Cargo.toml file to bump.
+    #[arg(short, long)]
+    manifest_path: String,
+
+    #[arg(short, long)]
+    bump: SemverBump,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SemverBump {
+    Major,
+    Minor,
+    Patch,
+}
+
+impl std::str::FromStr for SemverBump {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "major" => Ok(Self::Major),
+            "minor" => Ok(Self::Minor),
+            "patch" => Ok(Self::Patch),
+            _ => Err("valid options are 'major', 'minor' and 'patch'.".to_owned()),
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -11,3 +11,32 @@ test:
 
 test-with-coverage:
     cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
+    cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
+
+start-release-modeling-cmds:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+
+    # Bump the version.
+    next_version=$(cargo run --bin bumper -- --manifest-path modeling-cmds/Cargo.toml --bump patch)
+    cargo publish -p kittycad-modeling-cmds --dry-run --allow-dirty
+    git branch -c release/$next_version
+    git add --all
+    git commit -m "Release modeling commands $next_version"
+    git push
+    
+finish-release-modeling-cmds:
+    #!/usr/bin/env bash
+    set -euxo pipefail
+
+    # Check that the latest commit on `main` is the release we started.
+    git switch main
+    git pull
+    version=$(cargo run --bin bumper -- --manifest-path modeling-cmds/Cargo.toml)
+    latest_commit_msg=$(git show --oneline -s)
+    echo $latest_commit_msg | grep "Release modeling commands $version"
+
+    # If so, then tag and publish.
+    git tag kittycad-modeling-cmds-$version
+    git push --tags
+    cargo publish -p kittycad-modeling-cmds


### PR DESCRIPTION
- Adds 'bumper', a Rust project to get and bump the version of Rust packages
- Adds a `justfle` script to open a release PR for modeling-cmds
- Adds a `justfile` script to publish a release of modeling-cmds from main