### PR TITLE
Parameterize release scripts by package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,16 +11,15 @@
 
 # Releasing a crate
 
-In this example we'll use the modeling-cmds crate and release version 0.1.15, but you can follow
-the same procedure for any of the crates in this repo, and any version.
+This repo uses a `justfile`. Be sure to [install `just`](https://github.com/casey/just?tab=readme-ov-file#packages) if you haven't already.
 
-You should **only ever bump the patch** e.g. go from 0.1.22 to 0.1.23 -- otherwise you'll need to open PRs to KittyCAD's format and engine repos to explicitly bump them to 0.2.
+ - Create a release branch: `just start-release modeling-cmds`.
+ - Open a PR (hint: `just start-release` output should include a link to GitHub which will open a release PR).
+ - Merge the PR
+ - Run `just finish-release modeling-cmds`.
 
-We do *not* consider adding a new variant to `enum ModelingCmd` to be a breaking change.
+The `just` scripts above accept any workspace member as their first argument. For example, you could replace `modeling-cmds` with `execution-plan-traits` there.
 
-- `git checkout -b release/modeling-cmds/0.1.15`
-- Edit `modeling-cmds/Cargo.toml` and update the `version` field
-- `git add --all && git commit -m "Release modeling commands 0.1.15" && git push`
-- Open a PR from your branch into `main` and merge it.
-- `git checkout main && git tag kittycad-modeling-cmds-0.1.15 && git push --tags`
-- `cargo publish -p kittycad-modeling-cmds`
+## Note on semver
+
+The `just` scripts also accept a second arg, which defaults to `patch` -- this is the kind of semver bump to make. Technically you can specify `minor` or `major` too, but you should **almost always just bump the patch** e.g. go from 0.1.22 to 0.1.23. We don't really care about semver accuracy as Zoo engineers are the only people using this crate currently. Once other users need these crates, we'll start enforcing semver -- until then, convenience is really what matters. If you ever bump `modeling-cmds` major/minor versions, you'll need to open PRs to KittyCAD's format and engine repos to explicitly bump them to 0.2. Talk to Adam Chalmers before bumping the minor or major version.

--- a/justfile
+++ b/justfile
@@ -12,31 +12,43 @@ test:
 test-with-coverage:
     cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
 
-start-release-modeling-cmds:
+# Must be invoked with a package e.g.
+# `just start-release modeling-cmds`
+start-release pkg bump='patch':
     #!/usr/bin/env bash
     set -euxo pipefail
+    
+    # Validate that the argument is a valid project in this repo.
+    ls {{pkg}} || { print "No such package {{pkg}}"; exit 2; }
 
     # Bump the version.
-    next_version=$(cargo run --bin bumper -- --manifest-path modeling-cmds/Cargo.toml --bump patch)
-    cargo publish -p kittycad-modeling-cmds --dry-run --allow-dirty
+    next_version=$(cargo run --bin bumper -- --manifest-path {{pkg}}/Cargo.toml --bump {{bump}})
+    cargo publish -p kittycad-{{pkg}} --dry-run --allow-dirty
     just lint
-    git checkout -b release/modeling-cmds/$next_version
+
+    # Prepare the release PR.
+    git checkout -b release/{{pkg}}/$next_version
     git add --all
     git commit -m "Release modeling commands $next_version"
     git push
     
-finish-release-modeling-cmds:
+# Must be invoked with a package e.g.
+# `just finish-release modeling-cmds`
+finish-release pkg:
     #!/usr/bin/env bash
     set -euxo pipefail
 
-    # Check that the latest commit on `main` is the release we started.
+    # Validate that the argument is a valid project in this repo.
+    ls {{pkg}} || { print "No such package {{pkg}}"; exit 2; }
+
+    # Validate that the latest commit on `main` is the release we started.
     git switch main
     git pull
-    version=$(cargo run --bin bumper -- --manifest-path modeling-cmds/Cargo.toml)
+    version=$(cargo run --bin bumper -- --manifest-path {{pkg}}/Cargo.toml)
     latest_commit_msg=$(git show --oneline -s)
     echo $latest_commit_msg | grep "Release modeling commands $version"
 
     # If so, then tag and publish.
-    git tag kittycad-modeling-cmds-$version
+    git tag kittycad-{{pkg}}-$version
     git push --tags
-    cargo publish -p kittycad-modeling-cmds
+    cargo publish -p kittycad-{{pkg}}

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ start-release pkg bump='patch':
     set -euxo pipefail
     
     # Validate that the argument is a valid project in this repo.
-    ls {{pkg}} || { print "No such package {{pkg}}"; exit 2; }
+    ls {{pkg}} || { echo "No such package {{pkg}} in this Cargo workspace"; exit 2; }
 
     # Bump the version.
     next_version=$(cargo run --bin bumper -- --manifest-path {{pkg}}/Cargo.toml --bump {{bump}})
@@ -41,14 +41,14 @@ finish-release pkg:
     set -euxo pipefail
 
     # Validate that the argument is a valid project in this repo.
-    ls {{pkg}} || { print "No such package {{pkg}}"; exit 2; }
+    ls {{pkg}} || { echo "No such package {{pkg}} in this Cargo workspace"; exit 2; }
 
     # Validate that the latest commit on `main` is the release we started.
-    git switch main
-    git pull
+    # git switch main
+    # git pull
     version=$(cargo run --bin bumper -- --manifest-path {{pkg}}/Cargo.toml)
     latest_commit_msg=$(git show --oneline -s)
-    echo "$latest_commit_msg" | grep "Release modeling commands $version"
+    echo "$latest_commit_msg" | grep "Release modeling commands $version" || { echo "The latest commit on `main` is not a release commit. Did you open a PR with just start-release? Did you merge it?"; exit 2; }
 
     # If so, then tag and publish.
     git tag kittycad-{{pkg}}-$version

--- a/justfile
+++ b/justfile
@@ -6,14 +6,16 @@ lint:
 check-typos:
     codespell --config .codespellrc
 
+# Run unit tests
 test:
     cargo nextest --all-features run
 
+# Run unit tests, output coverage to `lcov.info`.
 test-with-coverage:
     cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
 
-# Must be invoked with a package e.g.
-# `just start-release modeling-cmds`
+# e.g. `just start-release modeling-cmds`
+# Opens a release PR for a package in this workspace
 start-release pkg bump='patch':
     #!/usr/bin/env bash
     set -euxo pipefail
@@ -32,8 +34,8 @@ start-release pkg bump='patch':
     git commit -m "Release modeling commands $next_version"
     git push
     
-# Must be invoked with a package e.g.
-# `just finish-release modeling-cmds`
+# e.g. `just finish-release modeling-cmds`
+# Assuming you just merged the PR from the `start-release` recipe, publishes (to crates.io) the release for a package in this workspace, 
 finish-release pkg:
     #!/usr/bin/env bash
     set -euxo pipefail
@@ -46,7 +48,7 @@ finish-release pkg:
     git pull
     version=$(cargo run --bin bumper -- --manifest-path {{pkg}}/Cargo.toml)
     latest_commit_msg=$(git show --oneline -s)
-    echo $latest_commit_msg | grep "Release modeling commands $version"
+    echo "$latest_commit_msg" | grep "Release modeling commands $version"
 
     # If so, then tag and publish.
     git tag kittycad-{{pkg}}-$version


### PR DESCRIPTION
Now the release scripts can work on any package and any kind of semver bump.