### PR TITLE
Fix justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ start-release pkg bump='patch':
     # Prepare the release PR.
     git checkout -b release/{{pkg}}/$next_version
     git add --all
-    git commit -m "Release modeling commands $next_version"
+    git commit -m "Release {{pkg}} $next_version"
     git push
     
 # e.g. `just finish-release modeling-cmds`
@@ -48,7 +48,7 @@ finish-release pkg:
     git pull
     version=$(cargo run --bin bumper -- --manifest-path {{pkg}}/Cargo.toml)
     latest_commit_msg=$(git show --oneline -s)
-    echo "$latest_commit_msg" | grep "Release modeling commands $version" || { echo "The latest commit on `main` is not a release commit. Did you open a PR with just start-release? Did you merge it?"; exit 2; }
+    echo "$latest_commit_msg" | grep "Release {{pkg}} $version" || { echo "The latest commit on `main` is not a release commit. Did you open a PR with just start-release? Did you merge it?"; exit 2; }
 
     # If so, then tag and publish.
     git tag kittycad-{{pkg}}-$version


### PR DESCRIPTION
Releases for all crates had a git commit of "Release modeling commands" but it should be "Release execution-plan-traits" or whatever package you actually chose.