### PR TITLE
Fixes for the FromMemory derive

### DIFF
--- a/execution-plan-macros/src/derive_from_memory.rs
+++ b/execution-plan-macros/src/derive_from_memory.rs
@@ -18,7 +18,7 @@ pub(crate) fn impl_derive_from_memory(input: DeriveInput, root: &TokenStream2) -
             Fields::Unit => impl_on_struct_no_fields(span, name, generics, root),
         },
         _ => quote_spanned! {span =>
-            compile_error!("Value cannot be implemented on an enum or union type")
+            compile_error!("FromMemory cannot be implemented on an enum or union type")
         },
     }
 }
@@ -82,7 +82,7 @@ fn impl_on_struct_named_fields(
     let read_each_field = field_names.iter().map(|(ident, span)| {
         quote_spanned! {*span=>
             let #ident = fields.next()
-                .ok_or(#root::MemoryError::MemoryWrongSize)
+                .ok_or(#root::MemoryError::NotEnoughFields)
                 .and_then(|a| match a {
                     #root::InMemory::Address(a) => {
 

--- a/execution-plan-traits/src/lib.rs
+++ b/execution-plan-traits/src/lib.rs
@@ -108,6 +108,9 @@ pub enum MemoryError {
         /// Expected to be 1, but it was something else.
         actual_length: usize,
     },
+    /// You didn't supply enough fields -- you have to supply one field per field of the original struct
+    #[error("You didn't supply enough fields -- you have to supply one field per field of the original struct")]
+    NotEnoughFields,
 }
 
 fn csv(v: &[&'static str]) -> String {


### PR DESCRIPTION
Two problems:
 - Typo where an error message mentions the Value trait instead of the FromMemory trait
 - Confusing memory error -- the MemoryWrongSize error doesn't actually describe the problem, so I added a new error case instead.