### PR TITLE
KCVM: Instruction struct

### DIFF
--- a/execution-plan/src/lib.rs
+++ b/execution-plan/src/lib.rs
@@ -21,14 +21,14 @@ pub use self::arithmetic::{
     BinaryArithmetic, UnaryArithmetic,
 };
 use self::import_files::ImportFiles;
-pub use self::instruction::Instruction;
+pub use self::instruction::{Instruction, InstructionKind};
 
 pub mod api_request;
 mod arithmetic;
-/// Expose feature to import external geometry files.
-pub mod import_files;
 /// Defined constants and ability to create more.
 pub mod constants;
+/// Expose feature to import external geometry files.
+pub mod import_files;
 mod instruction;
 mod memory;
 pub mod sketch_types;

--- a/execution-plan/src/sketch_types.rs
+++ b/execution-plan/src/sketch_types.rs
@@ -1,5 +1,5 @@
 //! Types for sketching models.
-use crate::{Destination, Instruction};
+use crate::{instruction::InstructionKind, Destination, Instruction};
 use kittycad_execution_plan_macros::ExecutionPlanValue;
 use kittycad_execution_plan_traits::{Address, Value};
 use kittycad_modeling_cmds::shared::{Point2d, Point3d, Point4d};
@@ -63,27 +63,27 @@ impl SketchGroup {
             + self.entity_id.into_parts().len();
         let mut out = vec![
             // Copy over the `from` field.
-            Instruction::Copy {
+            Instruction::from(InstructionKind::Copy {
                 source: start_point,
                 destination: Destination::Address(base_path_addr),
                 length: 1,
-            },
+            }),
             // Copy over the `to` field.
-            Instruction::Copy {
+            Instruction::from(InstructionKind::Copy {
                 source: start_point,
                 destination: Destination::Address(base_path_addr + self.path_first.from.into_parts().len()),
                 length: 1,
-            },
+            }),
         ];
         if let Some(tag) = tag {
             // Copy over the `name` field.
-            out.push(Instruction::Copy {
+            out.push(Instruction::from(InstructionKind::Copy {
                 source: tag,
                 destination: Destination::Address(
                     base_path_addr + self.path_first.from.into_parts().len() + self.path_first.to.into_parts().len(),
                 ),
                 length: 1,
-            });
+            }));
         }
         out
     }


### PR DESCRIPTION
Previously `Instruction` was an enum. That enum is now `InstructionKind` which is a field of the new struct `Instruction`.

This enables adding a `source_offset` field in the future. It would have been very annoying to add a `source_offset` field to each variant of the enum. Now it can be a field of the struct.