### PR TITLE
WIP Modeling-session: batch API request should return first failure, if any

### DIFF
--- a/execution-plan/src/api_request.rs
+++ b/execution-plan/src/api_request.rs
@@ -182,6 +182,6 @@ pub async fn flush_batch_queue(
         severity: Severity::Info,
         related_addresses: Default::default(),
     });
-    session.run_batch(batch_queue).await?;
+    dbg!(session.run_batch(batch_queue).await)?;
     Ok(())
 }

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -184,6 +184,25 @@ where
 
 impl<T> Point3d<T>
 where
+    T: kcep::Value,
+    kcep::Primitive: From<T>,
+{
+    /// Apply a function `f` to each component of the point.
+    pub fn map<U, F>(self, mut f: F) -> Point3d<U>
+    where
+        F: FnMut(T) -> U,
+        U: kcep::Value,
+        kcep::Primitive: From<U>,
+    {
+        let x: U = f(self.x);
+        let y: U = f(self.y);
+        let z: U = f(self.z);
+        Point3d { x, y, z }
+    }
+}
+
+impl<T> Point3d<T>
+where
     kcep::Primitive: From<T>,
     T: kcep::Value,
 {


### PR DESCRIPTION
Currently the API client in kittycad_modeling_session never actually checks the responses of commands submitted in a batch. But this is bad -- it really should let the user know if one of the commands failed.

This PR is currently not working -- I've written a program that should be invalid (because it tries to extend a path which doesn't exist), but it's not returning an error.