### PR TITLE
Generate engine actor enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,6 +1834,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "slog",
+ "tokio",
  "uuid",
  "webrtc",
 ]
@@ -1844,6 +1845,7 @@ version = "0.1.5"
 dependencies = [
  "anyhow",
  "insta",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -3799,9 +3801,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.0"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d45b238a16291a4e1584e61820b8ae57d696cc5015c459c229ccc6990cc1c"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",

--- a/modeling-cmds-macros/Cargo.toml
+++ b/modeling-cmds-macros/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+itertools = "0.12.1"
 proc-macro2 = "1.0.70"
 quote = "1.0.33"
 syn = { version = "2.0.41", features = ["extra-traits", "full"] }

--- a/modeling-cmds-macros/src/modeling_cmd_enum.rs
+++ b/modeling-cmds-macros/src/modeling_cmd_enum.rs
@@ -110,7 +110,9 @@ pub(crate) fn generate(input: ItemMod) -> TokenStream {
         pub enum ModelingCmdWithResp{#(
             #[doc = #docs]
             #variants{
+                /// Parameters for the request.
                 params: kittycad_modeling_cmds::each_cmd::#variants,
+                /// Channel the backend will send the response on.
                 response_sender: ::tokio::sync::oneshot::Sender<#response_type>,
             },
         )*}

--- a/modeling-cmds-macros/src/modeling_cmd_enum.rs
+++ b/modeling-cmds-macros/src/modeling_cmd_enum.rs
@@ -105,8 +105,7 @@ pub(crate) fn generate(input: ItemMod) -> TokenStream {
 
         /// Each modeling command, and a channel to receive a response.
         #[cfg(feature = "tokio")]
-        #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-        #[serde(rename_all = "snake_case")]
+        #[derive(Debug)]
         #[cfg_attr(not(unstable_exhaustive), non_exhaustive)]
         pub enum ModelingCmdWithResp{#(
             #[doc = #docs]

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -45,6 +45,7 @@ serde = { version = "1.0.193", features = ["derive"] }
 serde_bytes = "0.11.12"
 serde_json = { version = "1.0.108", optional = true }
 slog = { version = "2.7.0", optional = true }
+tokio = { version = "1.36.0", features = ["sync"], optional = true }
 uuid = { version = "1.6.1", features = ["serde"] }
 webrtc = { version = "0.9.0", optional = true }
 
@@ -58,3 +59,4 @@ cxx = ["dep:cxx"]
 diesel = ["dep:diesel"]
 websocket = ["dep:webrtc", "dep:serde_json"]
 unstable_exhaustive = []
+tokio = ["dep:tokio"]

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -25,19 +25,19 @@ define_ok_modeling_cmd_response_enum! {
         };
 
         /// The response from the `Export` endpoint.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct Export {
             /// The files that were exported.
             pub files: Vec<ExportFile>,
         }
         /// The response from the `SelectWithPoint` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct SelectWithPoint {
             /// The UUID of the entity that was selected.
             pub entity_id: Option<Uuid>,
         }
         /// The response from the `HighlightSetEntity` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct HighlightSetEntity {
             /// The UUID of the entity that was highlighted.
             pub entity_id: Option<Uuid>,
@@ -45,25 +45,25 @@ define_ok_modeling_cmd_response_enum! {
             pub sequence: Option<u32>,
         }
         /// The response from the `EntityGetChildUuid` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct EntityGetChildUuid {
             /// The UUID of the child entity.
             pub entity_id: Uuid,
         }
         /// The response from the `EntityGetNumChildren` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct EntityGetNumChildren {
             /// The number of children the entity has.
             pub num: u32,
         }
         /// The response from the `EntityGetParentId` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct EntityGetParentId {
             /// The UUID of the parent entity.
             pub entity_id: Uuid,
         }
         /// The response from the `EntityGetAllChildUuids` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct EntityGetAllChildUuids {
             /// The UUIDs of the child entities.
             pub entity_ids: Vec<Uuid>,
@@ -72,107 +72,107 @@ define_ok_modeling_cmd_response_enum! {
         /// The response from the `CameraDragMove` command.
         /// Note this is an "unreliable" channel message, so this data may need more data like a "sequence"
         //  to work properly
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct CameraDragMove {
             /// Camera settings
             pub settings: CameraSettings
         }
 
         /// The response from the `CameraDragEnd` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct CameraDragEnd {
             /// Camera settings
             pub settings: CameraSettings
         }
 
         /// The response from the `DefaultCameraGetSettings` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct DefaultCameraGetSettings {
             /// Camera settings
             pub settings: CameraSettings
         }
 
         /// The response from the `DefaultCameraZoom` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct DefaultCameraZoom {
             /// Camera settings
             pub settings: CameraSettings
         }
 
         /// The response from the `GetNumObjects` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct GetNumObjects {
             /// The number of objects in the scene.
             pub num_objects: u32,
         }
         /// The response from the `DefaultCameraFocusOn` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct DefaultCameraFocusOn { }
 
         /// The response from the `SelectGet` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct SelectGet {
             /// The UUIDs of the selected entities.
             pub entity_ids: Vec<Uuid>,
         }
 
         /// The response from the `Solid3dGetAllEdgeFaces` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct Solid3dGetAllEdgeFaces {
             /// The UUIDs of the faces.
             pub faces: Vec<Uuid>,
         }
 
         /// The response from the `Solid3dGetAllOppositeEdges` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct Solid3dGetAllOppositeEdges {
             /// The UUIDs of the edges.
             pub edges: Vec<Uuid>,
         }
 
         /// The response from the `Solid3dGetOppositeEdge` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct Solid3dGetOppositeEdge {
             /// The UUID of the edge.
             pub edge: Uuid,
         }
 
         /// The response from the `Solid3dGetNextAdjacentEdge` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct Solid3dGetNextAdjacentEdge {
             /// The UUID of the edge.
             pub edge: Option<Uuid>,
         }
 
         /// The response from the `Solid3dGetPrevAdjacentEdge` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct Solid3dGetPrevAdjacentEdge {
             /// The UUID of the edge.
             pub edge: Option<Uuid>,
         }
 
         /// The response from the `GetEntityType` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct GetEntityType {
             /// The type of the entity.
             pub entity_type: EntityType,
         }
         /// The response from the `CurveGetControlPoints` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct CurveGetControlPoints {
             /// Control points in the curve.
             pub control_points: Vec<Point3d>,
         }
 
         /// The response from the `CurveGetType` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct CurveGetType {
             /// Curve type
             pub curve_type: CurveType,
         }
 
         /// The response from the `MouseClick` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct MouseClick {
             /// Entities that are modified.
             pub entities_modified: Vec<Uuid>,
@@ -181,21 +181,21 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The response from the `TakeSnapshot` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct TakeSnapshot {
             /// Contents of the image.
             pub contents: Base64Data,
         }
 
         /// The response from the `PathGetInfo` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct PathGetInfo {
             /// All segments in the path, in the order they were added.
             pub segments: Vec<PathSegmentInfo>,
         }
 
         /// Info about a path segment
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct PathSegmentInfo {
             /// Which command created this path?
             /// This field is absent if the path command is not actually creating a path segment,
@@ -208,21 +208,21 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The response from the `PathGetCurveUuidsForVertices` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct PathGetCurveUuidsForVertices {
             /// The UUIDs of the curve entities.
             pub curve_ids: Vec<Uuid>,
         }
 
         /// The response from the `PathGetVertexUuids` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct PathGetVertexUuids {
             /// The UUIDs of the vertex entities.
             pub vertex_ids: Vec<Uuid>,
         }
 
         /// Endpoints of a curve
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct CurveGetEndPoints {
             /// Start
             pub start: Point3d<LengthUnit>,
@@ -267,14 +267,14 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// Corresponding coordinates of given window coordinates, intersected on given plane.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct PlaneIntersectAndProject {
             /// Corresponding coordinates of given window coordinates, intersected on given plane.
             pub plane_coordinates: Option<Point2d<LengthUnit>>,
         }
 
         /// Data from importing the files
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct ImportFiles {
             /// ID of the imported 3D models within the scene.
             pub object_id: Uuid,
@@ -290,7 +290,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The mass response.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct Mass {
             /// The mass.
             pub mass: f64,
@@ -299,7 +299,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The volume response.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct Volume {
             /// The volume.
             pub volume: f64,
@@ -308,7 +308,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The density response.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct Density {
             /// The density.
             pub density: f64,
@@ -317,7 +317,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The surface area response.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct SurfaceArea {
             /// The surface area.
             pub surface_area: f64,
@@ -326,7 +326,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The center of mass response.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct CenterOfMass {
             /// The center of mass.
             pub center_of_mass: Point3d<f64>,
@@ -335,7 +335,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The plane for sketch mode.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct GetSketchModePlane {
             /// The x axis.
             pub x_axis: Point3d<f64>,
@@ -346,7 +346,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The response from the `EntitiesGetDistance` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct EntityGetDistance {
             /// The minimum distance between the input entities.
             pub min_distance: LengthUnit,
@@ -355,28 +355,28 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The response from the `EntityLinearPattern` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct EntityLinearPattern {
             /// The UUIDs of the entities that were created.
             pub entity_ids: Vec<Uuid>,
         }
 
         /// The response from the `EntityCircularPattern` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct EntityCircularPattern {
             /// The UUIDs of the entities that were created.
             pub entity_ids: Vec<Uuid>,
         }
 
         /// Extrusion face info struct (useful for maintaining mappings between source path segment ids and extrusion faces)
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct Solid3dGetExtrusionFaceInfo {
             /// Details of each face.
             pub faces: Vec<ExtrusionFaceInfo>,
         }
 
         /// Extrusion face info struct (useful for maintaining mappings between source path segment ids and extrusion faces)
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, ExecutionPlanValue, ModelingCmdOutput)]
         pub struct ExtrusionFaceInfo {
             /// Path component (curve) UUID.
             pub curve_id: Option<Uuid>,

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -663,7 +663,7 @@ pub enum CurveType {
 }
 
 /// A file to be exported to the client.
-#[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, PartialEq)]
 pub struct ExportFile {
     /// The name of the file.
     pub name: String,
@@ -765,7 +765,7 @@ impl From<EngineErrorCode> for http::StatusCode {
 impl_string_enum_sql! {FileImportFormat}
 
 /// Camera settings including position, center, fov etc
-#[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue, PartialEq)]
 pub struct CameraSettings {
     ///Camera position (vantage)
     pub pos: Point3d,


### PR DESCRIPTION
This will make it easier to implement new endpoints in the engine. Engine team won't have to update the engine actor enum, because it will be automatically generated from the modeling_api definitions. 

Sample output:


```rust
    pub enum ModelingCmdWithResp {
        ///Start a new path.
        StartPath {
            params: kittycad_modeling_cmds::each_cmd::StartPath,
            response_sender: ::tokio::sync::oneshot::Sender<()>,
        },
        ///Move the path's "pen".
        MovePathPen {
            params: kittycad_modeling_cmds::each_cmd::MovePathPen,
            response_sender: ::tokio::sync::oneshot::Sender<()>,
        },
        /**Extend a path by adding a new segment which starts at the path's "pen".
If no "pen" location has been set before (via `MovePen`), then the pen is at the origin.*/
        ExtendPath {
            params: kittycad_modeling_cmds::each_cmd::ExtendPath,
            response_sender: ::tokio::sync::oneshot::Sender<()>,
        },
        ///Command for extruding a solid 2d.
        Extrude {
            params: kittycad_modeling_cmds::each_cmd::Extrude,
            response_sender: ::tokio::sync::oneshot::Sender<()>,
        },
        ///Command for revolving a solid 2d.
        Revolve {
            params: kittycad_modeling_cmds::each_cmd::Revolve,
            response_sender: ::tokio::sync::oneshot::Sender<()>,
        },
        ///Command for revolving a solid 2d about a brep edge
        RevolveAboutEdge {
            params: kittycad_modeling_cmds::each_cmd::RevolveAboutEdge,
            response_sender: ::tokio::sync::oneshot::Sender<()>,
        },
        ///Closes a path, converting it to a 2D solid.
        ClosePath {
            params: kittycad_modeling_cmds::each_cmd::ClosePath,
            response_sender: ::tokio::sync::oneshot::Sender<()>,
        },
        ///Camera drag started.
        CameraDragStart {
            params: kittycad_modeling_cmds::each_cmd::CameraDragStart,
            response_sender: ::tokio::sync::oneshot::Sender<()>,
        },
        ///Camera drag continued.
        CameraDragMove {
            params: kittycad_modeling_cmds::each_cmd::CameraDragMove,
            response_sender: ::tokio::sync::oneshot::Sender<
                ::kittycad_modeling_cmds::output::CameraDragMove,
            >,
        },
        ///Camera drag ended
        CameraDragEnd {
            params: kittycad_modeling_cmds::each_cmd::CameraDragEnd,
            response_sender: ::tokio::sync::oneshot::Sender<
                ::kittycad_modeling_cmds::output::CameraDragEnd,
            >,
        },
}
```