### PR TITLE
Remove SketchMode commands

### DIFF
--- a/execution-plan/src/api_request.rs
+++ b/execution-plan/src/api_request.rs
@@ -99,16 +99,6 @@ impl ApiRequest {
                 log_req(events);
                 session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
             }
-            Endpoint::EnableSketchMode => {
-                let cmd = each_cmd::EnableSketchMode::from_memory(&mut arguments, mem, events)?;
-                log_req(events);
-                session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
-            }
-            Endpoint::SketchModeEnable => {
-                let cmd = each_cmd::SketchModeEnable::from_memory(&mut arguments, mem, events)?;
-                log_req(events);
-                session.run_command(cmd_id, ModelingCmd::from(cmd)).await?
-            }
             Endpoint::DefaultCameraZoom => {
                 let cmd = each_cmd::DefaultCameraZoom::from_memory(&mut arguments, mem, events)?;
                 log_req(events);
@@ -151,8 +141,6 @@ impl ApiRequest {
             Endpoint::TakeSnapshot => each_cmd::TakeSnapshot::from_memory(&mut arguments, mem, events)?.into(),
             Endpoint::ImportFiles => each_cmd::ImportFiles::from_memory(&mut arguments, mem, events)?.into(),
             Endpoint::MakePlane => each_cmd::MakePlane::from_memory(&mut arguments, mem, events)?.into(),
-            Endpoint::EnableSketchMode => each_cmd::EnableSketchMode::from_memory(&mut arguments, mem, events)?.into(),
-            Endpoint::SketchModeEnable => each_cmd::SketchModeEnable::from_memory(&mut arguments, mem, events)?.into(),
             Endpoint::DefaultCameraFocusOn => {
                 each_cmd::DefaultCameraFocusOn::from_memory(&mut arguments, mem, events)?.into()
             }

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -210,29 +210,6 @@ define_modeling_cmd_enum! {
             pub magnitude: f32,
         }
 
-        /// Enable sketch mode, where users can sketch 2D geometry.
-        /// Users choose a plane to sketch on.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ExecutionPlanFromMemory, ModelingCmdVariantEmpty)]
-        pub struct DefaultCameraEnableSketchMode {
-            /// What's the origin of the sketching plane?
-            pub origin: Point3d,
-            /// Which 3D axis of the scene should be the X axis of the sketching plane?
-            pub x_axis: Point3d,
-            /// Which 3D axis of the scene should be the Y axis of the sketching plane?
-            pub y_axis: Point3d,
-            /// How far to the sketching plane?
-            pub distance_to_plane: f32,
-            /// Should the camera use orthographic projection?
-            /// In other words, should an object's size in the rendered image stay constant regardless of its distance from the camera.
-            pub ortho: bool,
-            /// Should we animate or snap for the camera transition?
-            pub animated: bool,
-        }
-
-        /// Disable sketch mode, from the default camera.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ExecutionPlanFromMemory, ModelingCmdVariantEmpty)]
-        pub struct DefaultCameraDisableSketchMode;
-
         /// Export the scene to a file.
         #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
         pub struct Export {
@@ -638,27 +615,6 @@ define_modeling_cmd_enum! {
             pub window: Point2d,
         }
 
-        /// Enable sketch mode on the given plane.
-        /// If you want to sketch on a face, use `enable_sketch_mode` instead.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ExecutionPlanFromMemory, ModelingCmdVariantEmpty)]
-        pub struct SketchModeEnable {
-            /// Sketch on this plane.
-            pub plane_id: Uuid,
-            /// Use an orthographic camera.
-            pub ortho: bool,
-            /// Animate the transition to sketch mode.
-            pub animated: bool,
-            /// Disable the camera entirely for sketch mode and sketch on a plane (this would be the normal
-            /// of that plane).
-            pub disable_camera_with_plane: Option<Point3d<f64>>,
-        }
-
-        /// Disable sketch mode.
-        /// If you are sketching on a face, be sure to not disable sketch mode until you have extruded.
-        /// Otherwise, your object will not be fused with the face.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ExecutionPlanFromMemory, ModelingCmdVariantEmpty)]
-        pub struct SketchModeDisable;
-
         /// Get the plane for sketch mode.
         #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ExecutionPlanFromMemory, ModelingCmdVariant)]
         pub struct GetSketchModePlane;
@@ -672,20 +628,6 @@ define_modeling_cmd_enum! {
             pub constraint_bound: PathComponentConstraintBound,
             /// What part of the curve should be constrained.
             pub constraint_type: PathComponentConstraintType,
-        }
-
-        /// Sketch on some entity (e.g. a plane, a face).
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ExecutionPlanFromMemory, ModelingCmdVariantEmpty)]
-        pub struct EnableSketchMode {
-            /// Which entity to sketch on.
-            pub entity_id: Uuid,
-            /// Should the camera use orthographic projection?
-            /// In other words, should an object's size in the rendered image stay constant regardless of its distance from the camera.
-            pub ortho: bool,
-            /// Should we animate or snap for the camera transition?
-            pub animated: bool,
-            /// Should the camera move at all?
-            pub adjust_camera: bool,
         }
 
         /// Set the background color of the scene.


### PR DESCRIPTION
These aren't being used by the frontend, because of our current "client-side sketching" system Kurt made. So, instead, let's remove those endpoints. When we eventually move sketching back into the engine, we can add a new endpoint that actually works right.