### PR TITLE
Remove unused diesel feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,49 +917,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "diesel"
-version = "2.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62c6fcf842f17f8c78ecf7c81d75c5ce84436b41ee07e03f490fbb5f5a8731d8"
-dependencies = [
- "bigdecimal",
- "bitflags 2.4.1",
- "byteorder",
- "chrono",
- "diesel_derives",
- "mysqlclient-sys",
- "num-bigint",
- "num-integer",
- "num-traits 0.2.17",
- "percent-encoding",
- "r2d2",
- "serde_json",
- "url",
- "uuid",
-]
-
-[[package]]
-name = "diesel_derives"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef8337737574f55a468005a83499da720f20c65586241ffea339db9ecdfd2b44"
-dependencies = [
- "diesel_table_macro_syntax",
- "proc-macro2",
- "quote",
- "syn 2.0.52",
-]
-
-[[package]]
-name = "diesel_table_macro_syntax"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
-dependencies = [
- "syn 2.0.52",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,8 +1872,6 @@ dependencies = [
  "chrono",
  "cxx",
  "data-encoding",
- "diesel",
- "diesel_derives",
  "enum-iterator",
  "enum-iterator-derive",
  "euler",
@@ -2176,16 +2131,6 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "mysqlclient-sys"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61b381528ba293005c42a409dd73d034508e273bf90481f17ec2e964a6e969b"
-dependencies = [
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -2741,17 +2686,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "r2d2"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
-dependencies = [
- "log",
- "parking_lot 0.12.1",
- "scheduled-thread-pool",
-]
-
-[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,15 +3196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "scheduled-thread-pool"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
-dependencies = [
- "parking_lot 0.12.1",
 ]
 
 [[package]]

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -15,15 +15,6 @@ anyhow = "1.0.75"
 chrono = "0.4.35"
 cxx = { version = "1.0", optional = true }
 data-encoding = "2.5.0"
-diesel = { version = "2.1.1", features = [
-  "serde_json",
-  "mysql",
-  "chrono",
-  "r2d2",
-  "uuid",
-  "numeric",
-], optional = true }
-diesel_derives = "2.1.2"
 enum-iterator = "1.4.1"
 enum-iterator-derive = "1.2.1"
 euler = "0.4.1"
@@ -55,7 +46,6 @@ workspace = true
 default = []
 slog = ["dep:slog"]
 cxx = ["dep:cxx"]
-diesel = ["dep:diesel"]
 websocket = ["dep:webrtc", "dep:serde_json"]
 unstable_exhaustive = []
 

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -102,8 +102,6 @@ pub enum AnnotationTextAlignmentX {
     Right,
 }
 
-impl_string_enum_sql! {AnnotationTextAlignmentX}
-
 /// Vertical Text alignment
 #[allow(missing_docs)]
 #[derive(
@@ -128,8 +126,6 @@ pub enum AnnotationTextAlignmentY {
     Center,
     Top,
 }
-
-impl_string_enum_sql! {AnnotationTextAlignmentY}
 
 /// A point in 3D space
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Default, ExecutionPlanValue)]
@@ -183,8 +179,6 @@ pub enum AnnotationLineEnd {
     Arrow,
 }
 
-impl_string_enum_sql! {AnnotationLineEnd}
-
 /// The type of annotation
 #[derive(
     Display,
@@ -209,8 +203,6 @@ pub enum AnnotationType {
     /// 3D annotation type
     T3D,
 }
-
-impl_string_enum_sql! {AnnotationType}
 
 /// The type of camera drag interaction.
 #[derive(
@@ -495,8 +487,6 @@ pub enum SceneSelectionType {
     Remove,
 }
 
-impl_string_enum_sql! {SceneSelectionType}
-
 /// The type of scene's active tool
 #[allow(missing_docs)]
 #[derive(
@@ -526,8 +516,6 @@ pub enum SceneToolType {
     SketchCurveMod,
 }
 
-impl_string_enum_sql! {SceneToolType}
-
 /// The path component constraint bounds type
 #[allow(missing_docs)]
 #[derive(
@@ -554,8 +542,6 @@ pub enum PathComponentConstraintBound {
     PartiallyConstrained,
     FullyConstrained,
 }
-
-impl_string_enum_sql! {PathComponentConstraintBound}
 
 /// The path component constraint type
 #[allow(missing_docs)]
@@ -586,8 +572,6 @@ pub enum PathComponentConstraintType {
     Parallel,
     AngleBetween,
 }
-
-impl_string_enum_sql! {PathComponentConstraintType}
 
 /// The path component command type (within a Path)
 #[allow(missing_docs)]
@@ -722,8 +706,6 @@ pub enum FileExportFormat {
     Stl,
 }
 
-impl_string_enum_sql! {FileExportFormat}
-
 /// The valid types of source file formats.
 #[derive(
     Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Clone, Ord, PartialOrd, Sequence,
@@ -769,8 +751,6 @@ impl From<EngineErrorCode> for http::StatusCode {
         }
     }
 }
-
-impl_string_enum_sql! {FileImportFormat}
 
 /// Camera settings including position, center, fov etc
 #[derive(Debug, Serialize, Deserialize, JsonSchema, ExecutionPlanValue)]
@@ -856,7 +836,6 @@ pub enum GlobalAxis {
     /// The Z axis
     Z,
 }
-impl_string_enum_sql! {GlobalAxis}
 
 /// Possible types of faces which can be extruded from a 3D solid.
 #[derive(
@@ -885,7 +864,6 @@ pub enum ExtrusionFaceCapType {
     /// Capped below.
     Bottom,
 }
-impl_string_enum_sql! {ExtrusionFaceCapType}
 
 /// Post effect type
 #[allow(missing_docs)]
@@ -913,7 +891,6 @@ pub enum PostEffectType {
     #[default]
     NoEffect,
 }
-impl_string_enum_sql! {PostEffectType}
 
 // Enum: Connect Rust Enums to Cpp
 // add our native c++ names for our cxx::ExternType implementation

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -1,10 +1,3 @@
-#[cfg(feature = "diesel")]
-use std::str::FromStr;
-
-#[cfg(feature = "diesel")]
-use diesel::{mysql::Mysql, serialize::ToSql, sql_types::Text};
-#[cfg(feature = "diesel")]
-use diesel_derives::{AsExpression, FromSqlRow};
 use enum_iterator::Sequence;
 use kittycad_execution_plan_macros::ExecutionPlanValue;
 use kittycad_execution_plan_traits as kcep;
@@ -15,29 +8,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "cxx")]
 use crate::impl_extern_type;
 use crate::{length_unit::LengthUnit, units::UnitAngle};
-
-// A helper macro for allowing enums of only strings to be saved to the database.
-macro_rules! impl_string_enum_sql {
-    {$name:ident} => {
-        #[cfg(feature = "diesel")]
-        impl diesel::serialize::ToSql<Text, Mysql> for $name {
-            fn to_sql<'a>(&'a self, out: &mut diesel::serialize::Output<'a, '_, Mysql>) -> diesel::serialize::Result {
-                <String as ToSql<Text, Mysql>>::to_sql(&self.to_string(), &mut out.reborrow())
-            }
-        }
-
-        #[cfg(feature = "diesel")]
-        impl<DB> diesel::deserialize::FromSql<Text, DB> for $name
-        where
-            DB: diesel::backend::Backend,
-            String: diesel::deserialize::FromSql<Text, DB>,
-        {
-            fn from_sql(bytes: <DB as diesel::backend::Backend>::RawValue<'_>) -> diesel::deserialize::Result<Self> {
-                Ok(Self::from_str(&String::from_sql(bytes)?)?)
-            }
-        }
-    };
-}
 
 /// Options for annotations
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ExecutionPlanValue)]
@@ -125,8 +95,6 @@ pub struct Color {
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "lowercase")]
 pub enum AnnotationTextAlignmentX {
     Left,
@@ -154,8 +122,6 @@ impl_string_enum_sql! {AnnotationTextAlignmentX}
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "lowercase")]
 pub enum AnnotationTextAlignmentY {
     Bottom,
@@ -211,8 +177,6 @@ where
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "lowercase")]
 pub enum AnnotationLineEnd {
     None,
@@ -238,8 +202,6 @@ impl_string_enum_sql! {AnnotationLineEnd}
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "lowercase")]
 pub enum AnnotationType {
     /// 2D annotation type (screen or planar space)
@@ -267,8 +229,6 @@ impl_string_enum_sql! {AnnotationType}
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "lowercase")]
 pub enum CameraDragInteractionType {
     /// Camera pan
@@ -525,8 +485,6 @@ impl std::ops::AddAssign for Angle {
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "lowercase")]
 pub enum SceneSelectionType {
     /// Replaces the selection
@@ -557,8 +515,6 @@ impl_string_enum_sql! {SceneSelectionType}
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "snake_case")]
 pub enum SceneToolType {
     CameraRevolve,
@@ -591,8 +547,6 @@ impl_string_enum_sql! {SceneToolType}
     Default,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "snake_case")]
 pub enum PathComponentConstraintBound {
     #[default]
@@ -622,8 +576,6 @@ impl_string_enum_sql! {PathComponentConstraintBound}
     Default,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "snake_case")]
 pub enum PathComponentConstraintType {
     #[default]
@@ -655,8 +607,6 @@ impl_string_enum_sql! {PathComponentConstraintType}
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "snake_case")]
 pub enum PathCommand {
     MoveTo,
@@ -684,8 +634,6 @@ pub enum PathCommand {
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "lowercase")]
 #[repr(u8)]
 pub enum EntityType {
@@ -719,8 +667,6 @@ pub enum EntityType {
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "snake_case")]
 pub enum CurveType {
     Line,
@@ -741,8 +687,6 @@ pub struct ExportFile {
 #[derive(
     Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Clone, Ord, PartialOrd, Sequence,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "lowercase")]
 #[display(style = "lowercase")]
 pub enum FileExportFormat {
@@ -784,8 +728,6 @@ impl_string_enum_sql! {FileExportFormat}
 #[derive(
     Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Clone, Ord, PartialOrd, Sequence,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "lowercase")]
 #[display(style = "lowercase")]
 pub enum FileImportFormat {
@@ -905,8 +847,6 @@ pub struct PerspectiveCameraParameters {
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "lowercase")]
 pub enum GlobalAxis {
     /// The X axis
@@ -935,8 +875,6 @@ impl_string_enum_sql! {GlobalAxis}
     PartialOrd,
     ExecutionPlanValue,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "snake_case")]
 #[repr(u8)]
 pub enum ExtrusionFaceCapType {

--- a/modeling-cmds/src/units.rs
+++ b/modeling-cmds/src/units.rs
@@ -1,38 +1,8 @@
-#[cfg(feature = "diesel")]
-use std::str::FromStr;
-
-#[cfg(feature = "diesel")]
-use diesel::{mysql::Mysql, serialize::ToSql, sql_types::Text};
-#[cfg(feature = "diesel")]
-use diesel_derives::{AsExpression, FromSqlRow};
 use kittycad_execution_plan_macros::ExecutionPlanValue;
 use kittycad_unit_conversion_derive::UnitConversion;
 use parse_display_derive::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-// A helper macro for allowing enums of only strings to be saved to the database.
-macro_rules! impl_string_enum_sql {
-    {$name:ident} => {
-        #[cfg(feature = "diesel")]
-        impl diesel::serialize::ToSql<Text, Mysql> for $name {
-            fn to_sql<'a>(&'a self, out: &mut diesel::serialize::Output<'a, '_, Mysql>) -> diesel::serialize::Result {
-                <String as ToSql<Text, Mysql>>::to_sql(&self.to_string(), &mut out.reborrow())
-            }
-        }
-
-        #[cfg(feature = "diesel")]
-        impl<DB> diesel::deserialize::FromSql<Text, DB> for $name
-        where
-            DB: diesel::backend::Backend,
-            String: diesel::deserialize::FromSql<Text, DB>,
-        {
-            fn from_sql(bytes: <DB as diesel::backend::Backend>::RawValue<'_>) -> diesel::deserialize::Result<Self> {
-                Ok(Self::from_str(&String::from_sql(bytes)?)?)
-            }
-        }
-    };
-}
 
 /// The valid types of length units.
 #[derive(
@@ -112,8 +82,6 @@ impl UnitLength {
     PartialOrd,
     UnitConversion,
 )]
-#[cfg_attr(feature = "diesel", derive(AsExpression, FromSqlRow))]
-#[cfg_attr(feature = "diesel", diesel(sql_type = Text))]
 #[serde(rename_all = "snake_case")]
 #[display(style = "snake_case")]
 pub enum UnitAngle {

--- a/modeling-cmds/src/units.rs
+++ b/modeling-cmds/src/units.rs
@@ -91,8 +91,6 @@ pub enum UnitAngle {
     Radians,
 }
 
-impl_string_enum_sql!(UnitAngle);
-
 /// The valid types of area units.
 #[derive(
     Display,


### PR DESCRIPTION
I never noticed an issue when switching to CockroachDB, so I suspected that this feature wasn't actually being used. So, I disabled it and there were no issues. We never serialize these things to the DB anymore, and if we do it would be as JSON which we already have.