### PR TITLE
Ensure 'git push' in start-release works.

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ start-release pkg bump='patch':
     git checkout -b release/{{pkg}}/$next_version
     git add --all
     git commit -m "Release {{pkg}} $next_version"
-    git push
+    git push --set-upstream origin release/{{pkg}}/$next_version
     
 # e.g. `just finish-release modeling-cmds`
 # Assumes you just merged the PR from the `start-release` recipe.


### PR DESCRIPTION
Ben points out that 'git push' in just start-release won't work on many machines, it'll fail with the common git error message "the current branch $$$ has no upstream branch", and suggest pushing with --set-upstream. This works fine on my machine because my git config uses push.autoSetupRemote = true.

So, ensure you always use that flag when pushing the release branch.