### PR TITLE
Added commands for object transforming (translate, rotate and scale)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -1061,6 +1061,94 @@ define_modeling_cmd_enum! {
             Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariant,
         )]
         pub struct GetNumObjects;
+
+        ///Set the position of an object
+        #[derive(
+            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariantEmpty,
+        )]
+        pub struct SetObjectPosition
+        {
+            /// The object whose position is to be set
+            pub object_id: Uuid,
+            /// Position
+            pub position: Point3d
+        }
+
+        ///Translate an object (this is an offset from the current position, to set object to a
+        ///specific position use SetObjectPosition)
+        #[derive(
+            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariantEmpty,
+        )]
+        pub struct TranslateObject
+        {
+            /// The object to be translated
+            pub object_id: Uuid,
+            /// Translation
+            pub position: Point3d
+        }
+
+        ///Set the scale of an object
+        #[derive(
+            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariantEmpty,
+        )]
+        pub struct SetObjectScale
+        {
+            /// The object whose scale is to be set
+            pub object_id: Uuid,
+            /// Scale
+            pub scale: Point3d
+        }
+
+        ///Scale an object (this is an offset from the current scale, to set object to a
+        ///specific scale use SetObjectScale)
+        #[derive(
+            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariantEmpty,
+        )]
+        pub struct ScaleObject
+        {
+            /// The object to be scaled
+            pub object_id: Uuid,
+            /// Scale
+            pub scale: Point3d
+        }
+
+        ///Set the rotation of an object, the rotation is set using roll (x-axis) pitch (y-axis)
+        ///and yaw (z-axis)
+        #[derive(
+            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariantEmpty,
+        )]
+        pub struct SetObjectRotation
+        {
+            /// The object whose rotation is to be set
+            pub object_id: Uuid,
+            /// Roll, Pitch, Yaw values
+            pub rpy: Point3d
+        }
+
+        ///Rotate an object (this is an offset from the current rotation, to set object to a
+        ///specific rotation use SetObjectRotation)
+        #[derive(
+            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariantEmpty,
+        )]
+        pub struct RotateObject
+        {
+            /// The object whose rotation is to be set
+            pub object_id: Uuid,
+            /// Roll, Pitch, Yaw values
+            pub rpy: Point3d
+        }
+
+        ///Set the parent object of an object
+        #[derive(
+            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariantEmpty,
+        )]
+        pub struct SetObjectParent
+        {
+            ///The object (child) whose parent will be set
+            pub object_id: Uuid,
+            /// Id of the new parent, if null will unset any parent of object_id
+            pub parent_id: Option<Uuid>
+        }
     }
 }
 

--- a/modeling-cmds/src/format/fbx.rs
+++ b/modeling-cmds/src/format/fbx.rs
@@ -8,20 +8,7 @@ use serde::{Deserialize, Serialize};
 pub mod import {
     use super::*;
     /// Options for importing FBX.
-    #[derive(
-        Clone,
-        Debug,
-        Default,
-        Eq,
-        Hash,
-        PartialEq,
-        Serialize,
-        Deserialize,
-        JsonSchema,
-        Display,
-        FromStr,
-       
-    )]
+    #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
     #[display("")]
     #[serde(rename = "FbxImportOptions")]
     pub struct Options {}
@@ -64,19 +51,7 @@ pub mod export {
 
     /// Describes the storage format of an FBX file.
     #[derive(
-        Default,
-        Clone,
-        Copy,
-        Debug,
-        Eq,
-        Hash,
-        PartialEq,
-        Serialize,
-        Deserialize,
-        JsonSchema,
-        Display,
-        FromStr,
-       
+        Default, Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr,
     )]
     #[display(style = "snake_case")]
     #[serde(rename = "FbxStorage", rename_all = "snake_case")]

--- a/modeling-cmds/src/format/gltf.rs
+++ b/modeling-cmds/src/format/gltf.rs
@@ -1,4 +1,3 @@
-
 use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -8,20 +7,7 @@ pub mod import {
     use super::*;
 
     /// Options for importing glTF 2.0.
-    #[derive(
-        Clone,
-        Debug,
-        Default,
-        Eq,
-        Hash,
-        PartialEq,
-        Serialize,
-        Deserialize,
-        JsonSchema,
-        Display,
-        FromStr,
-       
-    )]
+    #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
     #[display("")]
     #[serde(rename = "GltfImportOptions")]
     pub struct Options {}

--- a/modeling-cmds/src/format/mod.rs
+++ b/modeling-cmds/src/format/mod.rs
@@ -1,4 +1,3 @@
-
 use parse_display_derive::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -53,9 +52,7 @@ pub enum OutputFormat {
 }
 
 /// Input format specifier.
-#[derive(
-    Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr,
-)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[display(style = "snake_case")]
 pub enum InputFormat {

--- a/modeling-cmds/src/format/obj.rs
+++ b/modeling-cmds/src/format/obj.rs
@@ -1,4 +1,3 @@
-
 use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -10,9 +9,7 @@ pub mod import {
     use super::*;
 
     /// Options for importing OBJ.
-    #[derive(
-        Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr,
-    )]
+    #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
     #[display("coords: {coords}, units: {units}")]
     #[serde(rename = "ObjImportOptions")]
     pub struct Options {

--- a/modeling-cmds/src/format/ply.rs
+++ b/modeling-cmds/src/format/ply.rs
@@ -1,4 +1,3 @@
-
 use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -10,9 +9,7 @@ pub mod import {
     use super::*;
 
     /// Options for importing PLY.
-    #[derive(
-        Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr,
-    )]
+    #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
     #[display("coords: {coords}, units: {units}")]
     #[serde(rename = "PlyImportOptions")]
     pub struct Options {

--- a/modeling-cmds/src/format/sldprt.rs
+++ b/modeling-cmds/src/format/sldprt.rs
@@ -1,25 +1,12 @@
 /// Import functionality.
 pub mod import {
-    
+
     use parse_display::{Display, FromStr};
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
 
     /// Options for importing SolidWorks parts.
-    #[derive(
-        Clone,
-        Debug,
-        Default,
-        Eq,
-        Hash,
-        PartialEq,
-        Serialize,
-        Deserialize,
-        JsonSchema,
-        Display,
-        FromStr,
-       
-    )]
+    #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
     #[display("split_closed_faces: {split_closed_faces}")]
     #[serde(default, rename = "SldprtImportOptions")]
     pub struct Options {

--- a/modeling-cmds/src/format/step.rs
+++ b/modeling-cmds/src/format/step.rs
@@ -1,4 +1,3 @@
-
 use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -10,19 +9,7 @@ pub mod import {
     use super::*;
 
     /// Options for importing STEP format.
-    #[derive(
-        Clone,
-        Debug,
-        Default,
-        Eq,
-        Hash,
-        PartialEq,
-        Serialize,
-        Deserialize,
-        JsonSchema,
-        Display,
-        FromStr,
-    )]
+    #[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
     #[display("split_closed_faces: {split_closed_faces}")]
     #[serde(default, rename = "StepImportOptions")]
     pub struct Options {

--- a/modeling-cmds/src/format/stl.rs
+++ b/modeling-cmds/src/format/stl.rs
@@ -1,4 +1,3 @@
-
 use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -10,9 +9,7 @@ pub mod import {
     use super::*;
 
     /// Options for importing STL.
-    #[derive(
-        Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr,
-    )]
+    #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
     #[display("coords: {coords}, units: {units}")]
     #[serde(rename = "StlImportOptions")]
     pub struct Options {

--- a/modeling-cmds/src/units.rs
+++ b/modeling-cmds/src/units.rs
@@ -1,4 +1,3 @@
-
 use kittycad_unit_conversion_derive::UnitConversion;
 use parse_display_derive::{Display, FromStr};
 use schemars::JsonSchema;


### PR DESCRIPTION

Added Commands to transform objects:

    - SetObject(Position/Rotation/Scale) will set the specified local value to the passed in argument
    - (Translate/Rotate/Scale)Object is a relative change based on the current local value. E.g. translate({5, 0, 0}) will move the object 5 units along the x-axis from say {11, 0, 0} to {16, 0, 0}. SetObjectPosition({5, 0, 0}) will set the position to {5, 0, 0}
    - SetObjectParent will set the parent object of an object. The object (child) will inherit its parent's local values and its values will be applied on top of those values

