### PR TITLE
Release modeling-cmds 0.2.45

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.44"
+version = "0.2.45"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.44"
+version = "0.2.45"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Changes

- The "unstable_exhaustive" feature now works properly (disables the `#[non_exhaustive]` annotation, allowing you to opt into breaking changes when we add more variants of modeling commands)