### PR TITLE
Add option to make shell hollow

### DIFF
--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -119,7 +119,8 @@ define_modeling_cmd_enum! {
             /// Smaller values mean a thinner shell.
             pub shell_thickness: LengthUnit,
             /// If true, the Solid3D is made hollow instead of removing the selected faces
-            pub hollow: Option<bool>,
+            #[serde(default)]
+            pub hollow: bool,
         }
 
         /// Command for revolving a solid 2d about a brep edge

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -118,6 +118,8 @@ define_modeling_cmd_enum! {
             /// How thick the shell should be.
             /// Smaller values mean a thinner shell.
             pub shell_thickness: LengthUnit,
+            /// If true, the Solid3D is made hollow instead of removing the selected faces
+            pub hollow: Option<bool>,
         }
 
         /// Command for revolving a solid 2d about a brep edge


### PR DESCRIPTION
Can now specify if you want to "hollow out" the solid instead of deleting the selected faces to make a shell. All new geometry will be inside the solid