### PR TITLE
Remove cap field

### DIFF
--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -86,10 +86,6 @@ define_modeling_cmd_enum! {
             pub target: ModelingCmdId,
             /// How far off the plane to extrude
             pub distance: LengthUnit,
-            /// Whether to cap the extrusion with a face, or not.
-            /// If true, the resulting solid will be closed on all sides, like a dice.
-            /// If false, it will be open on one side, like a drinking glass.
-            pub cap: bool,
         }
 
         /// Command for revolving a solid 2d.

--- a/modeling-session/examples/cube_png.rs
+++ b/modeling-session/examples/cube_png.rs
@@ -105,7 +105,6 @@ async fn main() -> Result<()> {
         .run_command(
             random_id(),
             Extrude {
-                cap: true,
                 distance: CUBE_WIDTH * 2.0,
                 target: path,
             }

--- a/modeling-session/examples/cube_png_batch.rs
+++ b/modeling-session/examples/cube_png_batch.rs
@@ -96,7 +96,6 @@ async fn main() -> Result<()> {
     });
     sketch_batch.push(ModelingCmdReq {
         cmd: ModelingCmd::Extrude(Extrude {
-            cap: true,
             distance: CUBE_WIDTH * 2.0,
             target: path,
         }),

--- a/modeling-session/examples/lsystem_png_batch.rs
+++ b/modeling-session/examples/lsystem_png_batch.rs
@@ -135,7 +135,6 @@ async fn main() -> Result<()> {
     });
     sketch_batch.push(ModelingCmdReq {
         cmd: ModelingCmd::Extrude(Extrude {
-            cap: true,
             distance: LengthUnit(1.0),
             target: path,
         }),


### PR DESCRIPTION
The engine doesn't really support `cap: false` anymore, and the modeling app always uses `cap: true`. You can achieve something similar by shelling the top face of a 3d object.