### PR TITLE
Release modeling-cmds 0.2.60

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.59"
+version = "0.2.60"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.59"
+version = "0.2.60"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Additions

- `tabled` feature for deriving `tabled::Tabled`
- `convert_client_crate` impls `From` between this crate's and [lib.rs/kittycad] crate's types
- Impl many arithmetic operations on Point2d/3d
- `Point3d<T>` has a new method, `.with_w(self, T) -> Point4d<T>` (adds a `w` component to make the point 4d)