### PR TITLE
New methods to set just one component of a point

### DIFF
--- a/modeling-cmds/src/shared/point.rs
+++ b/modeling-cmds/src/shared/point.rs
@@ -1,6 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+mod only;
+
 /// A point in 2D space
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename = "Point2d")]
@@ -10,6 +12,12 @@ pub struct Point2d<T = f32> {
     pub x: T,
     #[allow(missing_docs)]
     pub y: T,
+}
+
+impl std::fmt::Display for Point2d<f64> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({}, {})", self.x, self.y)
+    }
 }
 
 impl<T: PartialEq> PartialEq for Point2d<T> {
@@ -145,6 +153,12 @@ pub struct Point4d<T = f32> {
     pub z: T,
     #[allow(missing_docs)]
     pub w: T,
+}
+
+impl std::fmt::Display for Point4d<f64> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({}, {}, {}, {})", self.x, self.y, self.z, self.w)
+    }
 }
 
 impl<T> Point4d<T> {

--- a/modeling-cmds/src/shared/point/only.rs
+++ b/modeling-cmds/src/shared/point/only.rs
@@ -1,0 +1,51 @@
+use super::{Point2d, Point3d, Point4d};
+
+macro_rules! impl_only {
+    ($typ:ident, $method:ident, $component:ident, $($i:ident),*) => {
+        impl<T> $typ<T>
+        where
+            T: Default,
+        {
+            /// Set only the given component.
+            /// All other components have their default value
+            pub fn $method($component: T) -> Self {
+                Self {
+                    $component,
+                    $(
+                        $i: Default::default(),
+                    )*
+                }
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all() {
+        assert_eq!(Point2d::only_x(1), Point2d { x: 1, y: 0 });
+        assert_eq!(Point2d::only_y(1), Point2d { x: 0, y: 1 });
+
+        assert_eq!(Point3d::only_x(1), Point3d { x: 1, y: 0, z: 0 });
+        assert_eq!(Point3d::only_y(1), Point3d { x: 0, y: 1, z: 0 });
+        assert_eq!(Point3d::only_z(1), Point3d { x: 0, y: 0, z: 1 });
+
+        assert_eq!(Point4d::only_x(1), Point4d { x: 1, y: 0, z: 0, w: 0 });
+        assert_eq!(Point4d::only_y(1), Point4d { x: 0, y: 1, z: 0, w: 0 });
+        assert_eq!(Point4d::only_z(1), Point4d { x: 0, y: 0, z: 1, w: 0 });
+        assert_eq!(Point4d::only_w(1), Point4d { x: 0, y: 0, z: 0, w: 1 });
+    }
+}
+
+impl_only!(Point2d, only_x, x, y);
+impl_only!(Point2d, only_y, y, x);
+impl_only!(Point3d, only_x, x, y, z);
+impl_only!(Point3d, only_y, y, x, z);
+impl_only!(Point3d, only_z, z, x, y);
+impl_only!(Point4d, only_x, x, y, z, w);
+impl_only!(Point4d, only_y, y, x, z, w);
+impl_only!(Point4d, only_z, z, x, y, w);
+impl_only!(Point4d, only_w, w, x, y, z);

--- a/modeling-cmds/src/shared/point/only.rs
+++ b/modeling-cmds/src/shared/point/only.rs
@@ -6,8 +6,18 @@ macro_rules! impl_only {
         where
             T: Default,
         {
-            /// Set only the given component.
-            /// All other components have their default value
+            #[doc = concat!("Set the `", stringify!($component), "` component to the given value, and all other components to their default.\n")]
+            #[doc = "```\n"]
+            #[doc = concat!("use kittycad_modeling_cmds::shared::", stringify!($typ), ";")]
+            #[doc = concat!("let expected = ", stringify!($typ), "{")]
+            #[doc = concat!("\t", stringify!($component), ": 8,")]
+                    $(
+            #[doc = concat!("\t", stringify!($i), ": 0,")]
+                    )*
+            #[doc = "};"]
+            #[doc = concat!("let actual = ", stringify!($typ), "::only_", stringify!($component), "(8);")]
+            #[doc = "assert_eq!(actual, expected);"]
+            #[doc = "```\n"]
             pub fn $method($component: T) -> Self {
                 Self {
                     $component,


### PR DESCRIPTION
E.g. `Point3d::only_y(4.0)` is `(0, 4, 0)`.

I even generate the docs for these methods:

<img width="662" alt="Screenshot 2024-09-23 at 4 20 13 PM" src="https://github.com/user-attachments/assets/b958e325-c5e2-4597-af80-d247f394801c">
