### PR TITLE
Release modeling-cmds 0.2.62

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.61"
+version = "0.2.62"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.61"
+version = "0.2.62"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Fixes

- `Transform` was setting wrong default for its `scale` field when instantiated using the `Default` trait. It was (0, 0, 0) and is now (1, 1, 1).

# Additions

 - `impl Display for Point2d` and `Point4d`
 - New `::only_x` etc constructors for Point2d/3d/4d, to set one component and leave all others as their default.