### PR TITLE
(DO NOT MERGE) Stop deriving JsonSchema

### DIFF
--- a/modeling-cmds-macros-impl/src/modeling_cmd_enum.rs
+++ b/modeling-cmds-macros-impl/src/modeling_cmd_enum.rs
@@ -54,7 +54,7 @@ pub fn generate(input: ItemMod) -> TokenStream {
         /// Definition of each modeling command.
         #input
         /// Commands that the KittyCAD engine can execute.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+        #[derive(Debug, Clone, Serialize, Deserialize)]
         #[serde(rename_all = "snake_case", tag = "type")]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub enum ModelingCmd {#(

--- a/modeling-cmds-macros-impl/src/ok_modeling_cmd_response_enum.rs
+++ b/modeling-cmds-macros-impl/src/ok_modeling_cmd_response_enum.rs
@@ -25,7 +25,7 @@ pub fn generate(input: ItemMod) -> TokenStream {
         #input
         /// A successful response from a modeling command.
         /// This can be one of several types of responses, depending on the command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+        #[derive(Debug, Serialize, Deserialize, Clone)]
         #[serde(rename_all = "snake_case", tag = "type", content = "data")]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub enum OkModelingCmdResponse {

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -42,7 +42,7 @@ define_modeling_cmd_enum! {
 
         /// Start a new path.
         #[derive(
-            Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant,
+            Debug, Clone, Serialize, Deserialize, ModelingCmdVariant,
         )]
         pub struct StartPath;
 
@@ -54,7 +54,7 @@ define_modeling_cmd_enum! {
         /// to (1, 1, 0) with this command uses local coordinates. So, it would move the pen to
         /// (1, 1, 50) in global coordinates.
         #[derive(
-            Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant,
+            Debug, Clone, Serialize, Deserialize, ModelingCmdVariant,
         )]
         pub struct MovePathPen {
             /// The ID of the command which created the path.
@@ -66,7 +66,7 @@ define_modeling_cmd_enum! {
         /// Extend a path by adding a new segment which starts at the path's "pen".
         /// If no "pen" location has been set before (via `MovePen`), then the pen is at the origin.
         #[derive(
-            Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant,
+            Debug, Clone, Serialize, Deserialize, ModelingCmdVariant,
         )]
         pub struct ExtendPath {
             /// The ID of the command which created the path.
@@ -78,7 +78,7 @@ define_modeling_cmd_enum! {
 
         /// Command for extruding a solid 2d.
         #[derive(
-            Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant,
+            Debug, Clone, Serialize, Deserialize, ModelingCmdVariant,
         )]
         pub struct Extrude {
             /// Which sketch to extrude.
@@ -90,7 +90,7 @@ define_modeling_cmd_enum! {
 
         /// Command for revolving a solid 2d.
         #[derive(
-            Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant,
+            Debug, Clone, Serialize, Deserialize, ModelingCmdVariant,
         )]
         pub struct Revolve {
             /// Which sketch to revolve.
@@ -110,7 +110,7 @@ define_modeling_cmd_enum! {
 
         /// Command for shelling a solid3d face
         #[derive(
-            Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant,
+            Debug, Clone, Serialize, Deserialize, ModelingCmdVariant,
         )]
         pub struct Solid3dShellFace {
             /// Which Solid3D is being shelled.
@@ -127,7 +127,7 @@ define_modeling_cmd_enum! {
 
         /// Command for revolving a solid 2d about a brep edge
         #[derive(
-            Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant,
+            Debug, Clone, Serialize, Deserialize, ModelingCmdVariant,
         )]
         pub struct RevolveAboutEdge {
             /// Which sketch to revolve.
@@ -143,7 +143,7 @@ define_modeling_cmd_enum! {
 
         /// Command for lofting sections to create a solid
         #[derive(
-            Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant
+            Debug, Clone, Serialize, Deserialize, ModelingCmdVariant
         )]
         pub struct Loft {
             /// The closed section curves to create a lofted solid from.
@@ -165,7 +165,7 @@ define_modeling_cmd_enum! {
 
         /// Closes a path, converting it to a 2D solid.
         #[derive(
-            Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant,
+            Debug, Clone, Serialize, Deserialize, ModelingCmdVariant,
         )]
         pub struct ClosePath {
             /// Which path to close.
@@ -173,7 +173,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Camera drag started.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct CameraDragStart {
             /// The type of camera drag interaction.
             pub interaction: CameraDragInteractionType,
@@ -182,7 +182,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Camera drag continued.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct CameraDragMove {
             /// The type of camera drag interaction.
             pub interaction: CameraDragInteractionType,
@@ -196,7 +196,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Camera drag ended
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct CameraDragEnd {
             /// The type of camera drag interaction.
             pub interaction: CameraDragInteractionType,
@@ -205,11 +205,11 @@ define_modeling_cmd_enum! {
         }
 
         /// Gets the default camera's camera settings
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct DefaultCameraGetSettings;
 
         /// Change what the default camera is looking at.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct DefaultCameraLookAt {
             /// Where the camera is positioned
             pub vantage: Point3d,
@@ -225,7 +225,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Change what the default camera is looking at.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct DefaultCameraPerspectiveSettings {
             /// Where the camera is positioned
             pub vantage: Point3d,
@@ -247,7 +247,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Adjust zoom of the default camera.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct DefaultCameraZoom {
             /// Move the camera forward along the vector it's looking at,
             /// by this magnitudedefaultCameraZoom.
@@ -256,7 +256,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Export the scene to a file.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct Export {
             /// IDs of the entities to be exported. If this is empty, then all entities are exported.
             pub entity_ids: Vec<Uuid>,
@@ -265,21 +265,21 @@ define_modeling_cmd_enum! {
         }
 
         /// What is this entity's parent?
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityGetParentId {
             /// ID of the entity being queried.
             pub entity_id: Uuid,
         }
 
         /// How many children does the entity have?
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityGetNumChildren {
             /// ID of the entity being queried.
             pub entity_id: Uuid,
         }
 
         /// What is the UUID of this entity's n-th child?
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityGetChildUuid {
             /// ID of the entity being queried.
             pub entity_id: Uuid,
@@ -288,21 +288,21 @@ define_modeling_cmd_enum! {
         }
 
         /// What are all UUIDs of this entity's children?
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityGetAllChildUuids {
             /// ID of the entity being queried.
             pub entity_id: Uuid,
         }
 
         /// What are all UUIDs of all the paths sketched on top of this entity?
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityGetSketchPaths {
             /// ID of the entity being queried.
             pub entity_id: Uuid,
         }
 
         /// What is the distance between these two entities?
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityGetDistance {
             /// ID of the first entity being queried.
             pub entity_id1: Uuid,
@@ -314,7 +314,7 @@ define_modeling_cmd_enum! {
 
         /// Create a pattern using this entity by specifying the transform for each desired repetition.
         /// Transformations are performed in the following order (first applied to last applied): scale, rotate, translate.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityLinearPatternTransform {
             /// ID of the entity being copied.
             pub entity_id: Uuid,
@@ -325,7 +325,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Create a linear pattern using this entity.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityLinearPattern {
             /// ID of the entity being copied.
             pub entity_id: Uuid,
@@ -338,7 +338,7 @@ define_modeling_cmd_enum! {
             pub spacing: LengthUnit,
         }
         /// Create a circular pattern using this entity.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityCircularPattern {
             /// ID of the entity being copied.
             pub entity_id: Uuid,
@@ -357,7 +357,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Create a helix using the input cylinder and other specified parameters.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityMakeHelix {
             /// ID of the cylinder.
             pub cylinder_id: Uuid,
@@ -372,7 +372,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Mirror the input entities over the specified axis. (Currently only supports sketches)
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityMirror {
             /// ID of the mirror entities.
             pub ids: Vec<Uuid>,
@@ -384,7 +384,7 @@ define_modeling_cmd_enum! {
 
         /// Mirror the input entities over the specified edge. (Currently only supports sketches)
         #[derive(
-            Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant,
+            Debug, Clone, Serialize, Deserialize, ModelingCmdVariant,
         )]
        pub struct EntityMirrorAcrossEdge {
             /// ID of the mirror entities.
@@ -394,7 +394,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Enter edit mode
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EditModeEnter {
             /// The edit target
             pub target: Uuid,
@@ -402,7 +402,7 @@ define_modeling_cmd_enum! {
 
         /// Modifies the selection by simulating a "mouse click" at the given x,y window coordinate
         /// Returns ID of whatever was selected.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SelectWithPoint {
             /// Where in the window was selected
             pub selected_at_window: Point2d,
@@ -411,25 +411,25 @@ define_modeling_cmd_enum! {
         }
 
         /// Adds one or more entities (by UUID) to the selection.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SelectAdd {
             /// Which entities to select
             pub entities: Vec<Uuid>,
         }
 
         /// Removes one or more entities (by UUID) from the selection.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SelectRemove {
             /// Which entities to unselect
             pub entities: Vec<Uuid>,
         }
 
         /// Removes all of the Objects in the scene
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SceneClearAll;
 
         /// Replaces current selection with these entities (by UUID).
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SelectReplace {
             /// Which entities to select
             pub entities: Vec<Uuid>,
@@ -437,7 +437,7 @@ define_modeling_cmd_enum! {
 
         /// Changes the current highlighted entity to whichever one is at the given window coordinate.
         /// If there's no entity at this location, clears the highlight.
-        #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Copy, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct HighlightSetEntity {
             /// Coordinates of the window being clicked
             pub selected_at_window: Point2d,
@@ -449,14 +449,14 @@ define_modeling_cmd_enum! {
         }
 
         /// Changes the current highlighted entity to these entities.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct HighlightSetEntities {
             /// Highlight these entities.
             pub entities: Vec<Uuid>,
         }
 
         /// Create a new annotation
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct NewAnnotation {
             /// What should the annotation contain?
             pub options: AnnotationOptions,
@@ -467,7 +467,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Update an annotation
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct UpdateAnnotation {
             /// Which annotation to update
             pub annotation_id: Uuid,
@@ -477,14 +477,14 @@ define_modeling_cmd_enum! {
         }
 
         /// Changes visibility of scene-wide edge lines on brep solids
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EdgeLinesVisible {
             /// Whether or not the edge lines should be hidden.
             pub hidden: bool,
         }
 
         /// Hide or show an object
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct ObjectVisible {
             /// Which object to change
             pub object_id: Uuid,
@@ -493,14 +493,14 @@ define_modeling_cmd_enum! {
         }
 
         /// Bring an object to the front of the scene
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct ObjectBringToFront {
             /// Which object to change
             pub object_id: Uuid,
         }
 
         /// Set the material properties of an object
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct ObjectSetMaterialParamsPbr {
             /// Which object to change
             pub object_id: Uuid,
@@ -514,14 +514,14 @@ define_modeling_cmd_enum! {
             pub ambient_occlusion: f32,
         }
         /// What type of entity is this?
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct GetEntityType {
             /// ID of the entity being queried.
             pub entity_id: Uuid,
         }
 
         /// Gets all faces which use the given edge.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct Solid3dGetAllEdgeFaces {
             /// Which object is being queried.
             pub object_id: Uuid,
@@ -530,7 +530,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Add a hole to a Solid2d object before extruding it.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct Solid2dAddHole {
             /// Which object to add the hole to.
             pub object_id: Uuid,
@@ -539,7 +539,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Gets all edges which are opposite the given edge, across all possible faces.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct Solid3dGetAllOppositeEdges {
             /// Which object is being queried.
             pub object_id: Uuid,
@@ -550,7 +550,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Gets the edge opposite the given edge, along the given face.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct Solid3dGetOppositeEdge {
             /// Which object is being queried.
             pub object_id: Uuid,
@@ -561,7 +561,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Gets the next adjacent edge for the given edge, along the given face.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct Solid3dGetNextAdjacentEdge {
             /// Which object is being queried.
             pub object_id: Uuid,
@@ -572,7 +572,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Gets the previous adjacent edge for the given edge, along the given face.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct Solid3dGetPrevAdjacentEdge {
             /// Which object is being queried.
             pub object_id: Uuid,
@@ -583,7 +583,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Fillets the given edge with the specified radius.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct Solid3dFilletEdge {
             /// Which object is being filletted.
             pub object_id: Uuid,
@@ -603,14 +603,14 @@ define_modeling_cmd_enum! {
         }
 
         /// Determines whether a brep face is planar and returns its surface-local planar axes if so
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct FaceIsPlanar {
             /// Which face is being queried.
             pub object_id: Uuid,
         }
 
         /// Determines a position on a brep face evaluated by parameters u,v
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct FaceGetPosition {
             /// Which face is being queried.
             pub object_id: Uuid,
@@ -620,14 +620,14 @@ define_modeling_cmd_enum! {
         }
 
         ///Obtains the surface "center of mass"
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct FaceGetCenter {
             /// Which face is being queried.
             pub object_id: Uuid,
         }
 
         /// Determines the gradient (dFdu, dFdv) + normal vector on a brep face evaluated by parameters u,v
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct FaceGetGradient {
             /// Which face is being queried.
             pub object_id: Uuid,
@@ -637,7 +637,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Send object to front or back.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SendObject {
             /// Which object is being changed.
             pub object_id: Uuid,
@@ -645,7 +645,7 @@ define_modeling_cmd_enum! {
             pub front: bool,
         }
         /// Set opacity of the entity.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntitySetOpacity {
             /// Which entity is being changed.
             pub entity_id: Uuid,
@@ -656,7 +656,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Fade entity in or out.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EntityFade {
             /// Which entity is being changed.
             pub entity_id: Uuid,
@@ -668,7 +668,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Make a new plane
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct MakePlane {
             /// Origin of the plane
             pub origin: Point3d<LengthUnit>,
@@ -687,7 +687,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Set the color of a plane.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct PlaneSetColor {
             /// Which plane is being changed.
             pub plane_id: Uuid,
@@ -696,14 +696,14 @@ define_modeling_cmd_enum! {
         }
 
         /// Set the current tool.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SetTool {
             /// What tool should be active.
             pub tool: SceneToolType,
         }
 
         /// Send a mouse move event
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct MouseMove {
             /// Where the mouse is
             pub window: Point2d,
@@ -716,7 +716,7 @@ define_modeling_cmd_enum! {
 
         /// Send a mouse click event
         /// Updates modified/selected entities.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct MouseClick {
             /// Where the mouse is
             pub window: Point2d,
@@ -725,15 +725,15 @@ define_modeling_cmd_enum! {
         /// Disable sketch mode.
         /// If you are sketching on a face, be sure to not disable sketch mode until you have extruded.
         /// Otherwise, your object will not be fused with the face.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SketchModeDisable;
 
         /// Get the plane for sketch mode.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct GetSketchModePlane;
 
         /// Get the plane for sketch mode.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct CurveSetConstraint {
             /// Which curve to constrain.
             pub object_id: Uuid,
@@ -744,7 +744,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Sketch on some entity (e.g. a plane, a face).
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct EnableSketchMode {
             /// Which entity to sketch on.
             pub entity_id: Uuid,
@@ -761,42 +761,42 @@ define_modeling_cmd_enum! {
         }
 
         /// Set the background color of the scene.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SetBackgroundColor {
             /// The color to set the background to.
             pub color: Color,
         }
 
         /// Set the properties of the tool lines for the scene.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SetCurrentToolProperties {
             /// The color to set the tool line to.
             pub color: Option<Color>,
         }
 
         /// Set the default system properties used when a specific property isn't set.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SetDefaultSystemProperties {
             /// The default system color.
             pub color: Option<Color>,
         }
 
         /// Get type of the given curve.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct CurveGetType {
             /// Which curve to query.
             pub curve_id: Uuid,
         }
 
         /// Get control points of the given curve.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct CurveGetControlPoints {
             /// Which curve to query.
             pub curve_id: Uuid,
         }
 
         /// Enum containing the variety of image formats snapshots may be exported to.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FromStr, Display)]
+        #[derive(Debug, Clone, Serialize, Deserialize, FromStr, Display)]
         #[serde(rename_all = "snake_case")]
         #[display(style = "snake_case")]
         pub enum ImageFormat {
@@ -807,14 +807,14 @@ define_modeling_cmd_enum! {
         }
 
         /// Take a snapshot of the current view.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct TakeSnapshot {
             /// What image format to return.
             pub format: ImageFormat,
         }
 
         /// Add a gizmo showing the axes.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct MakeAxesGizmo {
             /// If true, axes gizmo will be placed in the corner of the screen.
             /// If false, it will be placed at the origin of the scene.
@@ -824,14 +824,14 @@ define_modeling_cmd_enum! {
         }
 
         /// Query the given path.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct PathGetInfo {
             /// Which path to query
             pub path_id: Uuid,
         }
 
         /// Obtain curve ids for vertex ids
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct PathGetCurveUuidsForVertices {
             /// Which path to query
             pub path_id: Uuid,
@@ -841,7 +841,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Obtain curve id by index
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct PathGetCurveUuid {
             /// Which path to query
             pub path_id: Uuid,
@@ -851,28 +851,28 @@ define_modeling_cmd_enum! {
         }
 
         /// Obtain vertex ids for a path
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct PathGetVertexUuids {
             /// Which path to query
             pub path_id: Uuid,
         }
 
         /// Obtain the sketch target id (if the path was drawn in sketchmode) for a path
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct PathGetSketchTargetUuid {
             /// Which path to query
             pub path_id: Uuid,
         }
 
         /// Start dragging the mouse.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct HandleMouseDragStart {
             /// The mouse position.
             pub window: Point2d,
         }
 
         /// Continue dragging the mouse.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct HandleMouseDragMove {
             /// The mouse position.
             pub window: Point2d,
@@ -884,14 +884,14 @@ define_modeling_cmd_enum! {
         }
 
         /// Stop dragging the mouse.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct HandleMouseDragEnd {
             /// The mouse position.
             pub window: Point2d,
         }
 
         /// Remove scene objects.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct RemoveSceneObjects {
             /// Objects to remove.
             pub object_ids: HashSet<Uuid>,
@@ -899,7 +899,7 @@ define_modeling_cmd_enum! {
 
         /// Utility method. Performs both a ray cast and projection to plane-local coordinates.
         /// Returns the plane coordinates for the given window coordinates.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct PlaneIntersectAndProject {
             /// The plane you're intersecting against.
             pub plane_id: Uuid,
@@ -908,14 +908,14 @@ define_modeling_cmd_enum! {
         }
 
         /// Find the start and end of a curve.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct CurveGetEndPoints {
             /// ID of the curve being queried.
             pub curve_id: Uuid,
         }
 
         /// Reconfigure the stream.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct ReconfigureStream {
             /// Width of the stream.
             pub width: u32,
@@ -926,7 +926,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Import files to the current model.
-        #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct ImportFiles {
             /// Files to import.
             pub files: Vec<super::ImportFile>,
@@ -936,14 +936,14 @@ define_modeling_cmd_enum! {
 
         /// Set the units of the scene.
         /// For all following commands, the units will be interpreted as the given units.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SetSceneUnits {
             /// Which units the scene uses.
             pub unit: units::UnitLength,
         }
 
         /// Get the mass of entities in the scene or the default scene.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct Mass {
             /// IDs of the entities to get the mass of. If this is empty, then the default scene is included in
             /// the mass.
@@ -957,7 +957,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Get the density of entities in the scene or the default scene.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct Density {
             /// IDs of the entities to get the density of. If this is empty, then the default scene is included in
             /// the density.
@@ -971,7 +971,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Get the volume of entities in the scene or the default scene.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct Volume {
             /// IDs of the entities to get the volume of. If this is empty, then the default scene is included in
             /// the volume.
@@ -981,7 +981,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Get the center of mass of entities in the scene or the default scene.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct CenterOfMass {
             /// IDs of the entities to get the center of mass of. If this is empty, then the default scene is included in
             /// the center of mass.
@@ -991,7 +991,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Get the surface area of entities in the scene or the default scene.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct SurfaceArea {
             /// IDs of the entities to get the surface area of. If this is empty, then the default scene is included in
             /// the surface area.
@@ -1002,7 +1002,7 @@ define_modeling_cmd_enum! {
 
         /// Focus the default camera upon an object in the scene.
         #[derive(
-            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariant,
+            Clone, Debug, Deserialize, Serialize, ModelingCmdVariant,
         )]
         pub struct DefaultCameraFocusOn {
             /// UUID of object to focus on.
@@ -1010,7 +1010,7 @@ define_modeling_cmd_enum! {
         }
         /// When you select some entity with the current tool, what should happen to the entity?
         #[derive(
-            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariant,
+            Clone, Debug, Deserialize, Serialize, ModelingCmdVariant,
         )]
         pub struct SetSelectionType {
             /// What type of selection should occur when you select something?
@@ -1019,7 +1019,7 @@ define_modeling_cmd_enum! {
 
         /// What kind of entities can be selected?
         #[derive(
-            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariant,
+            Clone, Debug, Deserialize, Serialize, ModelingCmdVariant,
         )]
         pub struct SetSelectionFilter {
             /// If vector is empty, clear all filters.
@@ -1029,13 +1029,13 @@ define_modeling_cmd_enum! {
 
         /// Use orthographic projection.
         #[derive(
-            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariant,
+            Clone, Debug, Deserialize, Serialize, ModelingCmdVariant,
         )]
         pub struct DefaultCameraSetOrthographic;
 
         /// Use perspective projection.
         #[derive(
-            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariant,
+            Clone, Debug, Deserialize, Serialize, ModelingCmdVariant,
         )]
         pub struct DefaultCameraSetPerspective {
             /// If this is not given, use the same parameters as last time the perspective camera was used.
@@ -1043,7 +1043,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Fit the view to the specified object(s).
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct ZoomToFit {
             /// Which objects to fit camera to; if empty, fit to all non-default objects. Defaults to empty vector.
             #[serde(default = "default_uuid_vector")]
@@ -1059,7 +1059,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Fit the view to the scene with an isometric view.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdVariant)]
         pub struct ViewIsometric {
             /// How much to pad the view frame by.
             #[serde(default = "f32::default")]
@@ -1067,7 +1067,7 @@ define_modeling_cmd_enum! {
         }
 
         /// Get a concise description of all of an extrusion's faces.
-        #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariant)]
+        #[derive(Clone, Debug, Deserialize, Serialize, ModelingCmdVariant)]
         pub struct Solid3dGetExtrusionFaceInfo {
             /// The Solid3d object whose extrusion is being queried.
             pub object_id: Uuid,
@@ -1077,23 +1077,23 @@ define_modeling_cmd_enum! {
 
         /// Exit edit mode
         #[derive(
-            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariant,
+            Clone, Debug, Deserialize, Serialize, ModelingCmdVariant,
         )]
         pub struct EditModeExit;
 
         /// Clear the selection
         #[derive(
-            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariant,
+            Clone, Debug, Deserialize, Serialize, ModelingCmdVariant,
         )]
         pub struct SelectClear;
 
         /// Find all IDs of selected entities
-        #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariant)]
+        #[derive(Clone, Debug, Deserialize, Serialize, ModelingCmdVariant)]
         pub struct SelectGet;
 
         /// Get the number of objects in the scene
         #[derive(
-            Clone, Debug, Deserialize, JsonSchema, Serialize, ModelingCmdVariant,
+            Clone, Debug, Deserialize, Serialize, ModelingCmdVariant,
         )]
         pub struct GetNumObjects;
     }
@@ -1126,7 +1126,7 @@ impl ModelingCmd {
 /// File to import into the current model.
 /// If you are sending binary data for a file, be sure to send the WebSocketRequest as
 /// binary/bson, not text/json.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct ImportFile {
     /// The file's full path, including file extension.
     pub path: String,

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -1,5 +1,4 @@
 use kittycad_modeling_cmds_macros::define_ok_modeling_cmd_response_enum;
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 impl crate::ModelingCmdOutput for () {}
@@ -9,7 +8,6 @@ define_ok_modeling_cmd_response_enum! {
     pub mod output {
 
         use kittycad_modeling_cmds_macros::ModelingCmdOutput;
-        use schemars::JsonSchema;
         use serde::{Deserialize, Serialize};
         use uuid::Uuid;
         use crate::shared::CameraSettings;
@@ -24,283 +22,283 @@ define_ok_modeling_cmd_response_enum! {
         };
 
         /// The response from the `StartPath` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct StartPath {
         }
 
         /// The response from the `MovePathPen` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct MovePathPen {
         }
 
         /// The response from the `ExtendPath` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct ExtendPath {
         }
 
         /// The response from the `Extrude` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Extrude {
         }
 
         /// The response from the `Revolve` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Revolve {
         }
 
         /// The response from the `Solid3dShellFace` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Solid3dShellFace {
         }
 
         /// The response from the `RevolveAboutEdge` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct RevolveAboutEdge {
         }
 
         /// The response from the `CameraDragStart` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct CameraDragStart {
         }
 
         /// The response from the `DefaultCameraLookAt` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct DefaultCameraLookAt {
         }
 
         /// The response from the `DefaultCameraPerspectiveSettings` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct DefaultCameraPerspectiveSettings {
         }
 
         /// The response from the `EntityMakeHelix` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityMakeHelix {
         }
 
         /// The response from the `EntityMirror` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityMirror {
         }
 
         /// The response from the `EntityMirrorAcrossEdge` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityMirrorAcrossEdge {
         }
 
         /// The response from the `EditModeEnter` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EditModeEnter {
         }
 
         /// The response from the `SelectAdd` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SelectAdd {
         }
         /// The response from the `SelectRemove` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SelectRemove {
         }
 
         /// The response from the `SceneClearAll` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SceneClearAll {
         }
 
         /// The response from the `SelectReplace` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SelectReplace {
         }
 
         /// The response from the `HighlightSetEntities` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct HighlightSetEntities {
         }
 
         /// The response from the `NewAnnotation` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct NewAnnotation {
         }
 
         /// The response from the `UpdateAnnotation` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct UpdateAnnotation {
         }
 
         /// The response from the `EdgeLinesVisible` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EdgeLinesVisible {
         }
 
         /// The response from the `ObjectVisible` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct ObjectVisible {
         }
 
         /// The response from the `ObjectBringToFront` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct ObjectBringToFront {
         }
 
         /// The response from the `ObjectSetMaterialParamsPbr` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct ObjectSetMaterialParamsPbr {
         }
 
         /// The response from the `Solid2dAddHole` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Solid2dAddHole {
         }
 
         /// The response from the `Solid3dFilletEdge` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Solid3dFilletEdge {
         }
 
         /// The response from the `SendObject` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SendObject {
         }
 
         /// The response from the `EntitySetOpacity` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntitySetOpacity {
         }
 
         /// The response from the `EntityFade` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityFade {
         }
 
         /// The response from the `MakePlane` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct MakePlane {
         }
 
         /// The response from the `PlaneSetColor` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct PlaneSetColor {
         }
 
         /// The response from the `SetTool` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SetTool {
         }
 
         /// The response from the `MouseMove` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct MouseMove {
         }
 
         /// The response from the `SketchModeDisable` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SketchModeDisable {
         }
 
         /// The response from the `CurveSetConstraint` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct CurveSetConstraint {
         }
 
         /// The response from the `EnableSketchMode` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EnableSketchMode {
         }
 
         /// The response from the `SetBackgroundColor` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SetBackgroundColor {
         }
 
         /// The response from the `SetCurrentToolProperties` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SetCurrentToolProperties {
         }
 
         /// The response from the `SetDefaultSystemProperties` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SetDefaultSystemProperties {
         }
 
         /// The response from the `MakeAxesGizmo` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct MakeAxesGizmo {
         }
 
         /// The response from the `HandleMouseDragStart` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct HandleMouseDragStart {
         }
 
         /// The response from the `HandleMouseDragMove` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct HandleMouseDragMove {
         }
 
         /// The response from the `HandleMouseDragEnd` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct HandleMouseDragEnd {
         }
 
         /// The response from the `RemoveSceneObjects` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct RemoveSceneObjects {
         }
 
         /// The response from the `ReconfigureStream` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct ReconfigureStream {
         }
 
         /// The response from the `SetSceneUnits` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SetSceneUnits {
         }
 
         /// The response from the `SetSelectionType` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SetSelectionType {
         }
 
         /// The response from the `SetSelectionFilter` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SetSelectionFilter {
         }
 
         /// The response from the `DefaultCameraSetOrthographic` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct DefaultCameraSetOrthographic {
         }
 
         /// The response from the `DefaultCameraSetPerspective` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct DefaultCameraSetPerspective {
         }
 
         /// The response from the `EditModeExit` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EditModeExit {
         }
 
         /// The response from the `SelectClear` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SelectClear {
         }
 
         /// The response from the `Export` endpoint.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Export {
             /// The files that were exported.
             pub files: Vec<ExportFile>,
         }
         /// The response from the `SelectWithPoint` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SelectWithPoint {
             /// The UUID of the entity that was selected.
             pub entity_id: Option<Uuid>,
         }
         /// The response from the `HighlightSetEntity` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct HighlightSetEntity {
             /// The UUID of the entity that was highlighted.
             pub entity_id: Option<Uuid>,
@@ -308,46 +306,46 @@ define_ok_modeling_cmd_response_enum! {
             pub sequence: Option<u32>,
         }
         /// The response from the `EntityGetChildUuid` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityGetChildUuid {
             /// The UUID of the child entity.
             pub entity_id: Uuid,
         }
         /// The response from the `EntityGetNumChildren` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityGetNumChildren {
             /// The number of children the entity has.
             pub num: u32,
         }
         /// The response from the `EntityGetParentId` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityGetParentId {
             /// The UUID of the parent entity.
             pub entity_id: Uuid,
         }
         /// The response from the `EntityGetAllChildUuids` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityGetAllChildUuids {
             /// The UUIDs of the child entities.
             pub entity_ids: Vec<Uuid>,
         }
 
         /// The response from the `EntityGetSketchPaths` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityGetSketchPaths {
             /// The UUIDs of the sketch paths.
             pub entity_ids: Vec<Uuid>,
         }
 
         /// The response from the `Loft` command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, ModelingCmdOutput, Clone)]
+        #[derive(Debug, Serialize, Deserialize, ModelingCmdOutput, Clone)]
         pub struct Loft {
             ///The UUID of the newly created solid loft.
             pub solid_id: Uuid,
         }
 
         /// The response from the `ClosePath` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct ClosePath {
             /// The UUID of the lone face of the resulting solid2D.
             pub face_id: Uuid,
@@ -356,121 +354,121 @@ define_ok_modeling_cmd_response_enum! {
         /// The response from the `CameraDragMove` command.
         /// Note this is an "unreliable" channel message, so this data may need more data like a "sequence"
         //  to work properly
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct CameraDragMove {
             /// Camera settings
             pub settings: CameraSettings
         }
 
         /// The response from the `CameraDragEnd` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct CameraDragEnd {
             /// Camera settings
             pub settings: CameraSettings
         }
 
         /// The response from the `DefaultCameraGetSettings` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct DefaultCameraGetSettings {
             /// Camera settings
             pub settings: CameraSettings
         }
 
         /// The response from the `DefaultCameraZoom` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct DefaultCameraZoom {
             /// Camera settings
             pub settings: CameraSettings
         }
 
         /// The response from the `ZoomToFit` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct ZoomToFit {
             /// Camera settings
             pub settings: CameraSettings
         }
 
         /// The response from the `ViewIsometric` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct ViewIsometric {
             /// Camera settings
             pub settings: CameraSettings
         }
 
         /// The response from the `GetNumObjects` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct GetNumObjects {
             /// The number of objects in the scene.
             pub num_objects: u32,
         }
         /// The response from the `DefaultCameraFocusOn` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct DefaultCameraFocusOn { }
 
         /// The response from the `SelectGet` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct SelectGet {
             /// The UUIDs of the selected entities.
             pub entity_ids: Vec<Uuid>,
         }
 
         /// The response from the `Solid3dGetAllEdgeFaces` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Solid3dGetAllEdgeFaces {
             /// The UUIDs of the faces.
             pub faces: Vec<Uuid>,
         }
 
         /// The response from the `Solid3dGetAllOppositeEdges` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Solid3dGetAllOppositeEdges {
             /// The UUIDs of the edges.
             pub edges: Vec<Uuid>,
         }
 
         /// The response from the `Solid3dGetOppositeEdge` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Solid3dGetOppositeEdge {
             /// The UUID of the edge.
             pub edge: Uuid,
         }
 
         /// The response from the `Solid3dGetNextAdjacentEdge` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Solid3dGetNextAdjacentEdge {
             /// The UUID of the edge.
             pub edge: Option<Uuid>,
         }
 
         /// The response from the `Solid3dGetPrevAdjacentEdge` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Solid3dGetPrevAdjacentEdge {
             /// The UUID of the edge.
             pub edge: Option<Uuid>,
         }
 
         /// The response from the `GetEntityType` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct GetEntityType {
             /// The type of the entity.
             pub entity_type: EntityType,
         }
         /// The response from the `CurveGetControlPoints` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct CurveGetControlPoints {
             /// Control points in the curve.
             pub control_points: Vec<Point3d<f64>>,
         }
 
         /// The response from the `CurveGetType` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, Eq, PartialEq, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq, ModelingCmdOutput)]
         pub struct CurveGetType {
             /// Curve type
             pub curve_type: CurveType,
         }
 
         /// The response from the `MouseClick` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct MouseClick {
             /// Entities that are modified.
             pub entities_modified: Vec<Uuid>,
@@ -479,21 +477,21 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The response from the `TakeSnapshot` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct TakeSnapshot {
             /// Contents of the image.
             pub contents: Base64Data,
         }
 
         /// The response from the `PathGetInfo` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct PathGetInfo {
             /// All segments in the path, in the order they were added.
             pub segments: Vec<PathSegmentInfo>,
         }
 
         /// Info about a path segment
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct PathSegmentInfo {
             /// Which command created this path?
             /// This field is absent if the path command is not actually creating a path segment,
@@ -506,35 +504,35 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The response from the `PathGetCurveUuidsForVertices` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct PathGetCurveUuidsForVertices {
             /// The UUIDs of the curve entities.
             pub curve_ids: Vec<Uuid>,
         }
 
         /// The response from the `PathGetCurveUuid` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct PathGetCurveUuid {
             /// The UUID of the curve entity.
             pub curve_id: Uuid,
         }
 
         /// The response from the `PathGetVertexUuids` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct PathGetVertexUuids {
             /// The UUIDs of the vertex entities.
             pub vertex_ids: Vec<Uuid>,
         }
 
         /// The response from the `PathGetSketchTargetUuid` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct PathGetSketchTargetUuid {
             /// The UUID of the sketch target.
             pub target_id: Option<Uuid>,
         }
 
         /// Endpoints of a curve
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct CurveGetEndPoints {
             /// Start
             pub start: Point3d<LengthUnit>,
@@ -543,7 +541,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// Surface-local planar axes (if available)
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdOutput)]
         pub struct FaceIsPlanar {
             /// plane's origin
             pub origin: Option<Point3d<LengthUnit>>,
@@ -559,21 +557,21 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The 3D position on the surface that was evaluated
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdOutput)]
         pub struct FaceGetPosition {
             /// The 3D position on the surface that was evaluated
             pub pos: Point3d<LengthUnit>,
         }
 
         /// The 3D center of mass on the surface
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdOutput)]
         pub struct FaceGetCenter {
             /// The 3D position on the surface center of mass
             pub pos: Point3d<LengthUnit>,
         }
 
         /// The gradient (dFdu, dFdv) + normal vector on a brep face
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Clone, Serialize, Deserialize, ModelingCmdOutput)]
         pub struct FaceGetGradient {
             /// dFdu
             pub df_du: Point3d<f64>,
@@ -586,21 +584,21 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// Corresponding coordinates of given window coordinates, intersected on given plane.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct PlaneIntersectAndProject {
             /// Corresponding coordinates of given window coordinates, intersected on given plane.
             pub plane_coordinates: Option<Point2d<LengthUnit>>,
         }
 
         /// Data from importing the files
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct ImportFiles {
             /// ID of the imported 3D models within the scene.
             pub object_id: Uuid,
         }
 
         /// Data from importing the files
-        #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Eq, PartialEq, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct ImportedGeometry {
             /// ID of the imported 3D models within the scene.
             pub id: Uuid,
@@ -609,7 +607,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The mass response.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         #[cfg_attr(feature = "tabled", derive(tabled::Tabled))]
         pub struct Mass {
             /// The mass.
@@ -619,7 +617,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The volume response.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         #[cfg_attr(feature = "tabled", derive(tabled::Tabled))]
         pub struct Volume {
             /// The volume.
@@ -629,7 +627,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The density response.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         #[cfg_attr(feature = "tabled", derive(tabled::Tabled))]
         pub struct Density {
             /// The density.
@@ -639,7 +637,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The surface area response.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         #[cfg_attr(feature = "tabled", derive(tabled::Tabled))]
         pub struct SurfaceArea {
             /// The surface area.
@@ -649,7 +647,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The center of mass response.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         #[cfg_attr(feature = "tabled", derive(tabled::Tabled))]
         pub struct CenterOfMass {
             /// The center of mass.
@@ -659,7 +657,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The plane for sketch mode.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct GetSketchModePlane {
             /// The origin.
             pub origin: Point3d<LengthUnit>,
@@ -672,7 +670,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The response from the `EntitiesGetDistance` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityGetDistance {
             /// The minimum distance between the input entities.
             pub min_distance: LengthUnit,
@@ -681,35 +679,35 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// The response from the `EntityLinearPatternTransform` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityLinearPatternTransform {
             /// The UUIDs of the entities that were created.
             pub entity_ids: Vec<Uuid>,
         }
 
         /// The response from the `EntityLinearPattern` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityLinearPattern {
             /// The UUIDs of the entities that were created.
             pub entity_ids: Vec<Uuid>,
         }
 
         /// The response from the `EntityCircularPattern` command.
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct EntityCircularPattern {
             /// The UUIDs of the entities that were created.
             pub entity_ids: Vec<Uuid>,
         }
 
         /// Extrusion face info struct (useful for maintaining mappings between source path segment ids and extrusion faces)
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct Solid3dGetExtrusionFaceInfo {
             /// Details of each face.
             pub faces: Vec<ExtrusionFaceInfo>,
         }
 
         /// Extrusion face info struct (useful for maintaining mappings between source path segment ids and extrusion faces)
-        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, ModelingCmdOutput)]
         pub struct ExtrusionFaceInfo {
             /// Path component (curve) UUID.
             pub curve_id: Option<Uuid>,

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -12,7 +12,7 @@ pub use point::{Point2d, Point3d, Point4d, Quaternion};
 mod point;
 
 /// What kind of cut to do
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum CutType {
     /// Round off an edge.
@@ -23,7 +23,7 @@ pub enum CutType {
 }
 
 /// A rotation defined by an axis, origin of rotation, and an angle.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Rotation {
     /// Rotation axis.
@@ -48,7 +48,7 @@ impl Default for Rotation {
 }
 
 /// Ways to transform each solid being replicated in a repeating pattern.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Transform {
     /// Translate the replica this far along each dimension.
@@ -80,7 +80,7 @@ impl Default for Transform {
 }
 
 /// Options for annotations
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct AnnotationOptions {
     /// Text displayed on the annotation
@@ -96,7 +96,7 @@ pub struct AnnotationOptions {
 }
 
 /// Options for annotation text
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct AnnotationLineEndOptions {
     /// How to style the start of the annotation line.
@@ -106,7 +106,7 @@ pub struct AnnotationLineEndOptions {
 }
 
 /// Options for annotation text
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct AnnotationTextOptions {
     /// Alignment along the X axis
@@ -122,7 +122,7 @@ pub struct AnnotationTextOptions {
 /// The type of distance
 /// Distances can vary depending on
 /// the objects used as input.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum DistanceType {
     /// Euclidean Distance.
@@ -135,7 +135,7 @@ pub enum DistanceType {
 }
 
 /// The type of origin
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum OriginType {
     /// Local Origin (center of object bounding box).
@@ -151,7 +151,7 @@ pub enum OriginType {
 }
 
 /// An RGBA color
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Color {
     /// Red
     pub r: f32,
@@ -165,9 +165,7 @@ pub struct Color {
 
 /// Horizontal Text alignment
 #[allow(missing_docs)]
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "lowercase")]
 pub enum AnnotationTextAlignmentX {
     Left,
@@ -177,9 +175,7 @@ pub enum AnnotationTextAlignmentX {
 
 /// Vertical Text alignment
 #[allow(missing_docs)]
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "lowercase")]
 pub enum AnnotationTextAlignmentY {
     Bottom,
@@ -189,9 +185,7 @@ pub enum AnnotationTextAlignmentY {
 
 /// Annotation line end type
 #[allow(missing_docs)]
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "lowercase")]
 pub enum AnnotationLineEnd {
     None,
@@ -199,9 +193,7 @@ pub enum AnnotationLineEnd {
 }
 
 /// The type of annotation
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "lowercase")]
 pub enum AnnotationType {
     /// 2D annotation type (screen or planar space)
@@ -211,9 +203,7 @@ pub enum AnnotationType {
 }
 
 /// The type of camera drag interaction.
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "lowercase")]
 pub enum CameraDragInteractionType {
     /// Camera pan
@@ -226,7 +216,7 @@ pub enum CameraDragInteractionType {
 
 /// A segment of a path.
 /// Paths are composed of many segments.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum PathSegment {
     /// A straight line segment.
@@ -285,7 +275,7 @@ pub enum PathSegment {
 }
 
 /// An angle, with a specific unit.
-#[derive(Clone, Copy, PartialEq, Debug, JsonSchema, Deserialize, Serialize)]
+#[derive(Clone, Copy, PartialEq, Debug, Deserialize, Serialize)]
 pub struct Angle {
     /// What unit is the measurement?
     pub unit: UnitAngle,
@@ -373,9 +363,7 @@ impl std::ops::AddAssign for Angle {
 }
 
 /// The type of scene selection change
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "lowercase")]
 pub enum SceneSelectionType {
     /// Replaces the selection
@@ -388,9 +376,7 @@ pub enum SceneSelectionType {
 
 /// The type of scene's active tool
 #[allow(missing_docs)]
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 pub enum SceneToolType {
     CameraRevolve,
@@ -459,9 +445,7 @@ pub enum PathComponentConstraintType {
 
 /// The path component command type (within a Path)
 #[allow(missing_docs)]
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 pub enum PathCommand {
     MoveTo,
@@ -473,9 +457,7 @@ pub enum PathCommand {
 
 /// The type of entity
 #[allow(missing_docs)]
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "lowercase")]
 #[repr(u8)]
 pub enum EntityType {
@@ -493,9 +475,7 @@ pub enum EntityType {
 
 /// The type of Curve (embedded within path)
 #[allow(missing_docs)]
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 pub enum CurveType {
     Line,
@@ -504,7 +484,7 @@ pub enum CurveType {
 }
 
 /// A file to be exported to the client.
-#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ExportFile {
     /// The name of the file.
     pub name: String,
@@ -513,9 +493,7 @@ pub struct ExportFile {
 }
 
 /// The valid types of output file formats.
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Clone, Ord, PartialOrd, Sequence,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Clone, Ord, PartialOrd, Sequence)]
 #[serde(rename_all = "lowercase")]
 #[display(style = "lowercase")]
 pub enum FileExportFormat {
@@ -552,9 +530,7 @@ pub enum FileExportFormat {
 }
 
 /// The valid types of source file formats.
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Clone, Ord, PartialOrd, Sequence,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Clone, Ord, PartialOrd, Sequence)]
 #[serde(rename_all = "lowercase")]
 #[display(style = "lowercase")]
 pub enum FileImportFormat {
@@ -577,7 +553,7 @@ pub enum FileImportFormat {
 }
 
 /// The type of error sent by the KittyCAD graphics engine.
-#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Clone, Ord, PartialOrd)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 pub enum EngineErrorCode {
     /// User requested something geometrically or graphically impossible.
@@ -598,7 +574,7 @@ impl From<EngineErrorCode> for http::StatusCode {
 }
 
 /// Camera settings including position, center, fov etc
-#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CameraSettings {
     ///Camera position (vantage)
     pub pos: Point3d,
@@ -654,7 +630,7 @@ impl From<CameraSettings> for crate::output::ViewIsometric {
 }
 
 /// Defines a perspective view.
-#[derive(Copy, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Clone, PartialOrd, Default)]
+#[derive(Copy, PartialEq, Debug, Deserialize, Serialize, Clone, PartialOrd, Default)]
 #[serde(rename_all = "snake_case")]
 pub struct PerspectiveCameraParameters {
     /// Camera frustum vertical field of view.
@@ -666,9 +642,7 @@ pub struct PerspectiveCameraParameters {
 }
 
 /// The global axes.
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "lowercase")]
 pub enum GlobalAxis {
     /// The X axis
@@ -680,9 +654,7 @@ pub enum GlobalAxis {
 }
 
 /// Possible types of faces which can be extruded from a 3D solid.
-#[derive(
-    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd,
-)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Sequence, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 #[repr(u8)]
 pub enum ExtrusionFaceCapType {

--- a/modeling-cmds/src/shared/point.rs
+++ b/modeling-cmds/src/shared/point.rs
@@ -56,7 +56,7 @@ impl<T> Point2d<T> {
 }
 
 /// A point in 3D space
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Default)]
 #[serde(rename = "Point3d")]
 #[serde(rename_all = "snake_case")]
 pub struct Point3d<T = f32> {

--- a/modeling-cmds/src/traits.rs
+++ b/modeling-cmds/src/traits.rs
@@ -1,4 +1,3 @@
-use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::ModelingCmd;
@@ -14,7 +13,7 @@ pub trait ModelingCmdVariant: Serialize {
 }
 
 /// Anything that can be a ModelingCmd output.
-pub trait ModelingCmdOutput: std::fmt::Debug + Serialize + DeserializeOwned + JsonSchema {}
+pub trait ModelingCmdOutput: std::fmt::Debug + Serialize + DeserializeOwned {}
 
 impl<CmdVariant> From<CmdVariant> for ModelingCmd
 where

--- a/modeling-cmds/src/websocket.rs
+++ b/modeling-cmds/src/websocket.rs
@@ -3,7 +3,6 @@
 use std::{borrow::Cow, collections::HashMap};
 
 use parse_display_derive::{Display, FromStr};
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "slog")]
 use slog::{Record, Serializer, KV};
@@ -17,7 +16,7 @@ use crate::{
 };
 
 /// The type of error sent by the KittyCAD API.
-#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Clone, Ord, PartialOrd)]
+#[derive(Display, FromStr, Copy, Eq, PartialEq, Debug, Deserialize, Serialize, Clone, Ord, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 pub enum ErrorCode {
     /// Graphics engine failed to complete request, consider retrying
@@ -59,7 +58,7 @@ impl From<EngineErrorCode> for ErrorCode {
 }
 
 /// A graphics command submitted to the KittyCAD engine via the Modeling API.
-#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ModelingCmdReq {
     /// Which command to submit to the Kittycad engine.
     pub cmd: ModelingCmd,
@@ -68,7 +67,7 @@ pub struct ModelingCmdReq {
 }
 
 /// The websocket messages the server receives.
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WebSocketRequest {
     /// The trickle ICE candidate request.
@@ -103,7 +102,7 @@ pub enum WebSocketRequest {
 }
 
 /// A sequence of modeling requests. If any request fails, following requests will not be tried.
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct ModelingBatch {
     /// A sequence of modeling requests. If any request fails, following requests will not be tried.
@@ -144,7 +143,7 @@ impl ModelingBatch {
 /// Representation of an ICE server used for STUN/TURN
 /// Used to initiate WebRTC connections
 /// based on <https://developer.mozilla.org/en-US/docs/Web/API/RTCIceServer>
-#[derive(serde::Serialize, serde::Deserialize, Debug, JsonSchema, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 pub struct IceServer {
     /// URLs for a given STUN/TURN server.
     /// IceServer urls can either be a string or an array of strings
@@ -157,7 +156,7 @@ pub struct IceServer {
 }
 
 /// The websocket messages this server sends.
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum OkWebSocketResponseData {
     /// Information about the ICE servers.
@@ -207,7 +206,7 @@ pub enum OkWebSocketResponseData {
 }
 
 /// Successful Websocket response.
-#[derive(JsonSchema, Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct SuccessWebSocketResponse {
     /// Always true
@@ -222,7 +221,7 @@ pub struct SuccessWebSocketResponse {
 }
 
 /// Unsuccessful Websocket response.
-#[derive(JsonSchema, Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct FailureWebSocketResponse {
     /// Always false
@@ -237,7 +236,7 @@ pub struct FailureWebSocketResponse {
 
 /// Websocket responses can either be successful or unsuccessful.
 /// Slightly different schemas in either case.
-#[derive(JsonSchema, Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case", untagged)]
 pub enum WebSocketResponse {
     /// Response sent when a request succeeded.
@@ -248,7 +247,7 @@ pub enum WebSocketResponse {
 
 /// Websocket responses can either be successful or unsuccessful.
 /// Slightly different schemas in either case.
-#[derive(JsonSchema, Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case", untagged)]
 pub enum BatchResponse {
     /// Response sent when a request succeeded.
@@ -303,7 +302,7 @@ impl WebSocketResponse {
 
 /// A raw file with unencoded contents to be passed over binary websockets.
 /// When raw files come back for exports it is sent as binary/bson, not text/json.
-#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RawFile {
     /// The name of the file.
     pub name: String,
@@ -325,7 +324,7 @@ impl From<ExportFile> for RawFile {
 }
 
 /// An error with an internal message for logging.
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LoggableApiError {
     /// The error shown to users
     pub error: ApiError,
@@ -345,7 +344,7 @@ impl KV for LoggableApiError {
 }
 
 /// An error.
-#[derive(Debug, Serialize, Deserialize, JsonSchema, Eq, PartialEq, Clone)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct ApiError {
     /// The error code.
     pub error_code: ErrorCode,
@@ -392,7 +391,7 @@ impl ApiError {
 
 /// Serde serializes Result into JSON as "Ok" and "Err", but we want "ok" and "err".
 /// So, create a new enum that serializes as lowercase.
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", rename = "SnakeCaseResult")]
 pub enum SnakeCaseResult<T, E> {
     /// The result is Ok.
@@ -420,7 +419,7 @@ impl<T, E> From<Result<T, E>> for SnakeCaseResult<T, E> {
 }
 
 /// ClientMetrics contains information regarding the state of the peer.
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ClientMetrics {
     /// Counter of the number of WebRTC frames the client has dropped during
     /// this session.
@@ -466,7 +465,7 @@ pub struct ClientMetrics {
 }
 
 /// ICECandidate represents a ice candidate
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RtcIceCandidate {
     /// The stats ID.
     pub stats_id: String,
@@ -531,7 +530,7 @@ impl From<RtcIceCandidate> for webrtc::ice_transport::ice_candidate::RTCIceCandi
 }
 
 /// ICECandidateType represents the type of the ICE candidate used.
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RtcIceCandidateType {
     /// Unspecified indicates that the candidate type is unspecified.
@@ -597,7 +596,7 @@ impl From<RtcIceCandidateType> for webrtc::ice_transport::ice_candidate_type::RT
 
 /// ICEProtocol indicates the transport protocol type that is used in the
 /// ice.URL structure.
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RtcIceProtocol {
     /// Unspecified indicates that the protocol is unspecified.
@@ -634,7 +633,7 @@ impl From<RtcIceProtocol> for webrtc::ice_transport::ice_protocol::RTCIceProtoco
 }
 
 /// ICECandidateInit is used to serialize ice candidates
-#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 // These HAVE to be camel case as per the RFC.
 pub struct RtcIceCandidateInit {
@@ -677,7 +676,7 @@ impl From<RtcIceCandidateInit> for webrtc::ice_transport::ice_candidate::RTCIceC
 }
 
 /// SessionDescription is used to expose local and remote session descriptions.
-#[derive(Default, Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct RtcSessionDescription {
     /// SDP type.
     #[serde(rename = "type")]
@@ -721,7 +720,7 @@ impl TryFrom<RtcSessionDescription> for webrtc::peer_connection::sdp::session_de
 }
 
 /// SDPType describes the type of an SessionDescription.
-#[derive(Default, Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Default, Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RtcSdpType {
     /// Unspecified indicates that the type is unspecified.
@@ -777,7 +776,7 @@ impl From<RtcSdpType> for webrtc::peer_connection::sdp::sdp_type::RTCSdpType {
     }
 }
 /// Successful Websocket response.
-#[derive(JsonSchema, Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct ModelingSessionData {
     /// ID of the API call this modeling session is using.


### PR DESCRIPTION
Experimental. This reduces compiletime (release mode) from 75s to 15s.