### PR TITLE
Only impl Point::zero() for f64

### DIFF
--- a/modeling-cmds/src/shared/point/zero.rs
+++ b/modeling-cmds/src/shared/point/zero.rs
@@ -1,32 +1,22 @@
 use super::{Point2d, Point3d, Point4d};
 
-macro_rules! impl_zero {
-    ($t:ident, $zero:literal) => {
-        impl Point2d<$t> {
-            /// Set all components to zero.
-            pub const fn zero() -> Self {
-                Self::uniform($zero)
-            }
-        }
-        impl Point3d<$t> {
-            /// Set all components to zero.
-            pub const fn zero() -> Self {
-                Self::uniform($zero)
-            }
-        }
-        impl Point4d<$t> {
-            /// Set all components to zero.
-            pub const fn zero() -> Self {
-                Self::uniform($zero)
-            }
-        }
-    };
+impl Point2d<f64> {
+    /// Set all components to zero.
+    pub const fn zero() -> Self {
+        Self::uniform(0.0)
+    }
 }
 
-impl_zero!(u8, 0);
-impl_zero!(u16, 0);
-impl_zero!(u32, 0);
-impl_zero!(u64, 0);
-impl_zero!(u128, 0);
-impl_zero!(f32, 0.0);
-impl_zero!(f64, 0.0);
+impl Point3d<f64> {
+    /// Set all components to zero.
+    pub const fn zero() -> Self {
+        Self::uniform(0.0)
+    }
+}
+
+impl Point4d<f64> {
+    /// Set all components to zero.
+    pub const fn zero() -> Self {
+        Self::uniform(0.0)
+    }
+}


### PR DESCRIPTION
This is the only time we use it. Rust compiler gets confused and asks you to specify if you want the zero() method from f32, u8, u16, etc etc.

Easier to just only define it for f64, because that's the only time we ever actually use it.