### PR TITLE
Add new feature 'derive-jsonschema-on-enums'

### DIFF
--- a/modeling-cmds-macros-impl/src/modeling_cmd_enum.rs
+++ b/modeling-cmds-macros-impl/src/modeling_cmd_enum.rs
@@ -54,7 +54,8 @@ pub fn generate(input: ItemMod) -> TokenStream {
         /// Definition of each modeling command.
         #input
         /// Commands that the KittyCAD engine can execute.
-        #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        #[cfg_attr(feature = "derive-jsonschema-on-enums", derive(schemars::JsonSchema))]
         #[serde(rename_all = "snake_case", tag = "type")]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub enum ModelingCmd {#(

--- a/modeling-cmds-macros-impl/src/ok_modeling_cmd_response_enum.rs
+++ b/modeling-cmds-macros-impl/src/ok_modeling_cmd_response_enum.rs
@@ -25,7 +25,8 @@ pub fn generate(input: ItemMod) -> TokenStream {
         #input
         /// A successful response from a modeling command.
         /// This can be one of several types of responses, depending on the command.
-        #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        #[cfg_attr(feature = "derive-jsonschema-on-enums", derive(schemars::JsonSchema))]
         #[serde(rename_all = "snake_case", tag = "type", content = "data")]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub enum OkModelingCmdResponse {

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -44,6 +44,7 @@ workspace = true
 
 [features]
 default = []
+derive-jsonschema-on-enums = []
 tabled = ["dep:tabled"]
 slog = ["dep:slog"]
 cxx = ["dep:cxx"]

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -1,5 +1,4 @@
 use kittycad_modeling_cmds_macros::define_ok_modeling_cmd_response_enum;
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 impl crate::ModelingCmdOutput for () {}

--- a/modeling-cmds/src/websocket.rs
+++ b/modeling-cmds/src/websocket.rs
@@ -59,7 +59,8 @@ impl From<EngineErrorCode> for ErrorCode {
 }
 
 /// A graphics command submitted to the KittyCAD engine via the Modeling API.
-#[derive(Debug, Clone, JsonSchema, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "derive-jsonschema-on-enums", derive(schemars::JsonSchema))]
 pub struct ModelingCmdReq {
     /// Which command to submit to the Kittycad engine.
     pub cmd: ModelingCmd,
@@ -68,7 +69,8 @@ pub struct ModelingCmdReq {
 }
 
 /// The websocket messages the server receives.
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "derive-jsonschema-on-enums", derive(schemars::JsonSchema))]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WebSocketRequest {
     /// The trickle ICE candidate request.
@@ -103,7 +105,8 @@ pub enum WebSocketRequest {
 }
 
 /// A sequence of modeling requests. If any request fails, following requests will not be tried.
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "derive-jsonschema-on-enums", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub struct ModelingBatch {
     /// A sequence of modeling requests. If any request fails, following requests will not be tried.
@@ -157,7 +160,8 @@ pub struct IceServer {
 }
 
 /// The websocket messages this server sends.
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "derive-jsonschema-on-enums", derive(schemars::JsonSchema))]
 #[serde(tag = "type", content = "data", rename_all = "snake_case")]
 pub enum OkWebSocketResponseData {
     /// Information about the ICE servers.
@@ -207,7 +211,8 @@ pub enum OkWebSocketResponseData {
 }
 
 /// Successful Websocket response.
-#[derive(JsonSchema, Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "derive-jsonschema-on-enums", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case")]
 pub struct SuccessWebSocketResponse {
     /// Always true
@@ -237,7 +242,8 @@ pub struct FailureWebSocketResponse {
 
 /// Websocket responses can either be successful or unsuccessful.
 /// Slightly different schemas in either case.
-#[derive(JsonSchema, Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "derive-jsonschema-on-enums", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case", untagged)]
 pub enum WebSocketResponse {
     /// Response sent when a request succeeded.
@@ -248,7 +254,8 @@ pub enum WebSocketResponse {
 
 /// Websocket responses can either be successful or unsuccessful.
 /// Slightly different schemas in either case.
-#[derive(JsonSchema, Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "derive-jsonschema-on-enums", derive(schemars::JsonSchema))]
 #[serde(rename_all = "snake_case", untagged)]
 pub enum BatchResponse {
     /// Response sent when a request succeeded.


### PR DESCRIPTION
I've previously found that deriving JsonSchema on our big enums (of all modeling commands and all modeling command responses) takes compilation from 15s to 75s in release mode.

I tried to make all JsonSchema support conditional (via Cargo features) but realized that was a bad idea because basically every consumer of this crate needs JsonSchema support.

But, I recently realized that very few consumers need JsonSchema derived ON THE BIG ENUMS. Only the servers need that derive. The clients (like cli and kcl-lib) don't need that derive. They still want to derive JsonSchema on each individual modeling command (which is very fast) but not on the enum of all commands (which is slow).

Before this change, `cli` takes 2m4s seconds to compile (in release mode). After, it only takes 1m34s, which is a 25% reduction. No change on the compile-time of the frontend's `wasm-lib`.