### PR TITLE
Release modeling-cmds-macros-impl 0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds-macros-impl"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "criterion",

--- a/modeling-cmds-macros-impl/Cargo.toml
+++ b/modeling-cmds-macros-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds-macros-impl"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 repository = "https://github.com/KittyCAD/modeling-api"
 rust-version = "1.73"


### PR DESCRIPTION
# Changed

- `JsonSchema` impl for the big enums of all modeling commands (and all responses) is now behind a Cargo feature `derive-jsonschema-on-enums`.