### PR TITLE
Release modeling-cmds 0.2.67

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.66"
+version = "0.2.67"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.66"
+version = "0.2.67"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Changed

- `JsonSchema` is now implemented on big enums like `ModelingCmd` and `OkModelingCmdResponse` only if the Cargo feature `derive-jsonschema-on-enums` is enabled. This reduces compile-times for anyone consuming this library.