### PR TITLE
Release modeling-cmds 0.2.72

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.71"
+version = "0.2.72"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.71"
+version = "0.2.72"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Added

- On `ReconfigureStream`, new param for video `bitrace: Option<u32>` (defaults to current behaviour)
- New command `DefaultCameraCenterToScene`
- New field on `DefaultCameraCenterToSelection` called `camera_movement`