### PR TITLE
Extrude can send IDs for the new faces

### DIFF
--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -24,6 +24,7 @@ define_modeling_cmd_enum! {
                 Angle,
                 CutType,
                 CameraMovement,
+                ExtrudedFaceInfo,
                 AnnotationOptions, AnnotationType, CameraDragInteractionType, Color, DistanceType, EntityType,
                 PathComponentConstraintBound, PathComponentConstraintType, PathSegment, PerspectiveCameraParameters,
                 Point2d, Point3d, SceneSelectionType, SceneToolType,
@@ -99,6 +100,10 @@ define_modeling_cmd_enum! {
             pub target: ModelingCmdId,
             /// How far off the plane to extrude
             pub distance: LengthUnit,
+            /// Which IDs should the new faces have?
+            /// If this isn't given, the engine will generate IDs.
+            #[serde(default)]
+            pub faces: Option<ExtrudedFaceInfo>,
         }
 
         /// Command for revolving a solid 2d.

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -2,6 +2,7 @@ use enum_iterator::Sequence;
 use parse_display_derive::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 #[cfg(feature = "cxx")]
 use crate::impl_extern_type;
@@ -604,6 +605,29 @@ impl From<EngineErrorCode> for http::StatusCode {
             EngineErrorCode::InternalEngine => Self::INTERNAL_SERVER_ERROR,
         }
     }
+}
+
+/// IDs for the extruded faces.
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+pub struct ExtrudedFaceInfo {
+    /// The face made from the original 2D shape being extruded.
+    /// If the solid is extruded from a shape which already has an ID
+    /// (e.g. extruding something which was sketched on a face), this
+    /// doesn't need to be sent.
+    pub bottom: Option<Uuid>,
+    /// Top face of the extrusion (parallel and further away from the original 2D shape being extruded).
+    pub top: Uuid,
+    /// Any intermediate sides between the top and bottom.
+    pub sides: Vec<SideFace>,
+}
+
+/// IDs for a side face, extruded from the path of some sketch/2D shape.
+#[derive(Debug, Serialize, Deserialize, JsonSchema, Clone)]
+pub struct SideFace {
+    /// ID of the path this face is being extruded from.
+    pub path_id: Uuid,
+    /// Desired ID for the resulting face.
+    pub face_id: Uuid,
 }
 
 /// Camera settings including position, center, fov etc

--- a/modeling-session/examples/cube_png.rs
+++ b/modeling-session/examples/cube_png.rs
@@ -107,6 +107,7 @@ async fn main() -> Result<()> {
             Extrude {
                 distance: CUBE_WIDTH * 2.0,
                 target: path,
+                faces: None,
             }
             .into(),
         )

--- a/modeling-session/examples/cube_png_batch.rs
+++ b/modeling-session/examples/cube_png_batch.rs
@@ -98,6 +98,7 @@ async fn main() -> Result<()> {
         cmd: ModelingCmd::Extrude(Extrude {
             distance: CUBE_WIDTH * 2.0,
             target: path,
+            faces: None,
         }),
         cmd_id: random_id(),
     });

--- a/modeling-session/examples/lsystem_png_batch.rs
+++ b/modeling-session/examples/lsystem_png_batch.rs
@@ -137,6 +137,7 @@ async fn main() -> Result<()> {
         cmd: ModelingCmd::Extrude(Extrude {
             distance: LengthUnit(1.0),
             target: path,
+            faces: None,
         }),
         cmd_id: random_id(),
     });


### PR DESCRIPTION
When extruding a 2D shape into a 3D shape, a bunch of new faces are created. These faces need IDs. The backend currently generates these IDs randomly. Add a new option to allow the client to send the IDs.