### PR TITLE
Allow multiple transforms

### DIFF
--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -55,6 +55,7 @@ unstable_exhaustive = []
 
 [dev-dependencies]
 bson = "2.13.0"
+serde_json = "1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -26,7 +26,7 @@ define_modeling_cmd_enum! {
                 CameraMovement,
                 AnnotationOptions, AnnotationType, CameraDragInteractionType, Color, DistanceType, EntityType,
                 PathComponentConstraintBound, PathComponentConstraintType, PathSegment, PerspectiveCameraParameters,
-                Point2d, Point3d, SceneSelectionType, SceneToolType,
+                Point2d, Point3d, SceneSelectionType, SceneToolType, ScalarOrVec,
             },
             units,
         };
@@ -334,7 +334,7 @@ define_modeling_cmd_enum! {
             /// How to transform each repeated solid.
             /// The 0th transform will create the first copy of the entity.
             /// The total number of (optional) repetitions equals the size of this list.
-            pub transform: Vec<crate::shared::Transform>,
+            pub transform: Vec<ScalarOrVec<crate::shared::Transform>>,
         }
 
         /// Create a linear pattern using this entity.


### PR DESCRIPTION
Tackles issue https://github.com/KittyCAD/engine/issues/2774 in a different way to @gserena01 's PR https://github.com/KittyCAD/modeling-api/pull/629/, what do you think? This way clients can keep sending the same single transform, but can also send a vec of transforms.

