### PR TITLE
Release modeling-cmds 0.2.77

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.76"
+version = "0.2.77"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.76"
+version = "0.2.77"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Added

* Sweeps command
* New cap type, `::Both`