### PR TITLE
Release modeling-cmds 0.2.82

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.81"
+version = "0.2.82"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.81"
+version = "0.2.82"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Changed

 - list_faces() is now a method of ExtrudedFaceInfo not a free-floating function on the type.