### PR TITLE
loft return id

### DIFF
--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -219,6 +219,8 @@ define_modeling_cmd_enum! {
             pub base_curve_index: Option<u32>,
             /// Tolerance
             pub tolerance: LengthUnit,
+            /// If specified, the returned newly created loft id will match it.
+            pub new_loft_id: Option<Uuid>,
         }
 
 


### PR DESCRIPTION
Extends the Loft endpoint to allow the caller to specify the id of the loft