### PR TITLE
Add DXF as an exportable 2D format

### DIFF
--- a/modeling-cmds/src/convert_client_crate.rs
+++ b/modeling-cmds/src/convert_client_crate.rs
@@ -125,26 +125,26 @@ mod format {
         }
     }
 
-    impl From<InputFormat> for kt::InputFormat {
-        fn from(format: InputFormat) -> kt::InputFormat {
+    impl From<InputFormat3d> for kt::InputFormat {
+        fn from(format: InputFormat3d) -> kt::InputFormat {
             match format {
-                InputFormat::Fbx(fbx::import::Options {}) => kt::InputFormat::Fbx {},
-                InputFormat::Gltf(gltf::import::Options {}) => kt::InputFormat::Gltf {},
-                InputFormat::Obj(obj::import::Options { coords, units }) => kt::InputFormat::Obj {
+                InputFormat3d::Fbx(fbx::import::Options {}) => kt::InputFormat::Fbx {},
+                InputFormat3d::Gltf(gltf::import::Options {}) => kt::InputFormat::Gltf {},
+                InputFormat3d::Obj(obj::import::Options { coords, units }) => kt::InputFormat::Obj {
                     coords: coords.into(),
                     units: units.into(),
                 },
-                InputFormat::Ply(ply::import::Options { coords, units }) => kt::InputFormat::Ply {
+                InputFormat3d::Ply(ply::import::Options { coords, units }) => kt::InputFormat::Ply {
                     coords: coords.into(),
                     units: units.into(),
                 },
-                InputFormat::Sldprt(sldprt::import::Options { split_closed_faces }) => {
+                InputFormat3d::Sldprt(sldprt::import::Options { split_closed_faces }) => {
                     kt::InputFormat::Sldprt { split_closed_faces }
                 }
-                InputFormat::Step(step::import::Options { split_closed_faces }) => {
+                InputFormat3d::Step(step::import::Options { split_closed_faces }) => {
                     kt::InputFormat::Step { split_closed_faces }
                 }
-                InputFormat::Stl(stl::import::Options { coords, units }) => kt::InputFormat::Stl {
+                InputFormat3d::Stl(stl::import::Options { coords, units }) => kt::InputFormat::Stl {
                     coords: coords.into(),
                     units: units.into(),
                 },
@@ -152,7 +152,7 @@ mod format {
         }
     }
 
-    impl From<kt::InputFormat> for InputFormat {
+    impl From<kt::InputFormat> for InputFormat3d {
         fn from(value: kt::InputFormat) -> Self {
             match value {
                 kt::InputFormat::Fbx {} => Self::Fbx(Default::default()),

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -17,7 +17,7 @@ define_modeling_cmd_enum! {
         use uuid::Uuid;
 
         use crate::{
-            format::OutputFormat,
+            format::{OutputFormat2d, OutputFormat3d},
             id::ModelingCmdId,
             length_unit::LengthUnit,
             shared::{
@@ -326,15 +326,30 @@ define_modeling_cmd_enum! {
             pub magnitude: f32,
         }
 
+        /// Alias for backward compatibility.
+        #[deprecated(since = "0.2.96", note = "use `Export3d` instead")]
+        pub type Export = Export3d;
+
+        /// Export a sketch to a file.
+        #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+        #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+        pub struct Export2d {
+            /// IDs of the entities to be exported.
+            pub entity_ids: Vec<Uuid>,
+            /// The file format to export to.
+            pub format: OutputFormat2d,
+        }
+
         /// Export the scene to a file.
         #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
         #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
         #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-        pub struct Export {
+        pub struct Export3d {
             /// IDs of the entities to be exported. If this is empty, then all entities are exported.
             pub entity_ids: Vec<Uuid>,
             /// The file format to export to.
-            pub format: OutputFormat,
+            pub format: OutputFormat3d,
         }
 
         /// What is this entity's parent?

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -1259,7 +1259,7 @@ define_modeling_cmd_enum! {
             /// Files to import.
             pub files: Vec<super::ImportFile>,
             /// Input file format.
-            pub format: crate::format::InputFormat,
+            pub format: crate::format::InputFormat3d,
         }
 
         /// Set the units of the scene.

--- a/modeling-cmds/src/format/dxf.rs
+++ b/modeling-cmds/src/format/dxf.rs
@@ -9,7 +9,7 @@ pub mod export {
         Clone, Copy, Debug, Default, Deserialize, Display, Eq, FromStr, Hash, JsonSchema, PartialEq, Serialize,
     )]
     #[display(style = "snake_case")]
-    #[serde(rename = "StlStorage", rename_all = "snake_case")]
+    #[serde(rename = "DxfStorage", rename_all = "snake_case")]
     #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
     #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
     pub enum Storage {

--- a/modeling-cmds/src/format/dxf.rs
+++ b/modeling-cmds/src/format/dxf.rs
@@ -4,11 +4,33 @@ pub mod export {
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
 
+    /// Export storage.
+    #[derive(
+        Clone, Copy, Debug, Default, Deserialize, Display, Eq, FromStr, Hash, JsonSchema, PartialEq, Serialize,
+    )]
+    #[display(style = "snake_case")]
+    #[serde(rename = "StlStorage", rename_all = "snake_case")]
+    #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+    #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+    pub enum Storage {
+        /// Plaintext encoding.
+        ///
+        /// This is the default setting.
+        #[default]
+        Ascii,
+
+        /// Binary encoding.
+        Binary,
+    }
+
     /// Options for exporting DXF format.
     #[derive(Clone, Debug, Default, Deserialize, Display, Eq, FromStr, Hash, JsonSchema, PartialEq, Serialize)]
-    #[display("")]
+    #[display("storage: {storage}")]
     #[serde(rename = "DxfExportOptions")]
     #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
     #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-    pub struct Options {}
+    pub struct Options {
+        /// Export storage.
+        pub storage: Storage,
+    }
 }

--- a/modeling-cmds/src/format/dxf.rs
+++ b/modeling-cmds/src/format/dxf.rs
@@ -1,0 +1,14 @@
+/// Export sketches in DXF format.
+pub mod export {
+    use parse_display::{Display, FromStr};
+    use schemars::JsonSchema;
+    use serde::{Deserialize, Serialize};
+
+    /// Options for exporting DXF format.
+    #[derive(Clone, Debug, Default, Deserialize, Display, Eq, FromStr, Hash, JsonSchema, PartialEq, Serialize)]
+    #[display("")]
+    #[serde(rename = "DxfExportOptions")]
+    #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+    #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+    pub struct Options {}
+}

--- a/modeling-cmds/src/format/mod.rs
+++ b/modeling-cmds/src/format/mod.rs
@@ -37,13 +37,17 @@ pub enum OutputFormat2d {
     Dxf(dxf::export::Options),
 }
 
+/// Alias for backward compatibility.
+#[deprecated(since = "0.2.96", note = "use `OutputFormat3d` instead")]
+pub type OutputFormat = OutputFormat3d;
+
 /// Output 3D format specifier.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[display(style = "snake_case")]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-pub enum OutputFormat {
+pub enum OutputFormat3d {
     /// Autodesk Filmbox (FBX) format.
     #[display("{}: {0}")]
     Fbx(fbx::export::Options),
@@ -172,15 +176,15 @@ impl VirtualFile {
     }
 }
 
-impl From<OutputFormat> for FileExportFormat {
-    fn from(output_format: OutputFormat) -> Self {
+impl From<OutputFormat3d> for FileExportFormat {
+    fn from(output_format: OutputFormat3d) -> Self {
         match output_format {
-            OutputFormat::Fbx(_) => Self::Fbx,
-            OutputFormat::Gltf(_) => Self::Gltf,
-            OutputFormat::Obj(_) => Self::Obj,
-            OutputFormat::Ply(_) => Self::Ply,
-            OutputFormat::Step(_) => Self::Step,
-            OutputFormat::Stl(_) => Self::Stl,
+            OutputFormat3d::Fbx(_) => Self::Fbx,
+            OutputFormat3d::Gltf(_) => Self::Gltf,
+            OutputFormat3d::Obj(_) => Self::Obj,
+            OutputFormat3d::Ply(_) => Self::Ply,
+            OutputFormat3d::Step(_) => Self::Step,
+            OutputFormat3d::Stl(_) => Self::Stl,
         }
     }
 }
@@ -201,22 +205,22 @@ impl From<FileExportFormat2d> for OutputFormat2d {
     }
 }
 
-impl From<FileExportFormat> for OutputFormat {
+impl From<FileExportFormat> for OutputFormat3d {
     fn from(export_format: FileExportFormat) -> Self {
         match export_format {
-            FileExportFormat::Fbx => OutputFormat::Fbx(Default::default()),
-            FileExportFormat::Glb => OutputFormat::Gltf(gltf::export::Options {
+            FileExportFormat::Fbx => OutputFormat3d::Fbx(Default::default()),
+            FileExportFormat::Glb => OutputFormat3d::Gltf(gltf::export::Options {
                 storage: gltf::export::Storage::Binary,
                 ..Default::default()
             }),
-            FileExportFormat::Gltf => OutputFormat::Gltf(gltf::export::Options {
+            FileExportFormat::Gltf => OutputFormat3d::Gltf(gltf::export::Options {
                 storage: gltf::export::Storage::Embedded,
                 presentation: gltf::export::Presentation::Pretty,
             }),
-            FileExportFormat::Obj => OutputFormat::Obj(Default::default()),
-            FileExportFormat::Ply => OutputFormat::Ply(Default::default()),
-            FileExportFormat::Step => OutputFormat::Step(Default::default()),
-            FileExportFormat::Stl => OutputFormat::Stl(stl::export::Options {
+            FileExportFormat::Obj => OutputFormat3d::Obj(Default::default()),
+            FileExportFormat::Ply => OutputFormat3d::Ply(Default::default()),
+            FileExportFormat::Step => OutputFormat3d::Step(Default::default()),
+            FileExportFormat::Stl => OutputFormat3d::Stl(stl::export::Options {
                 storage: stl::export::Storage::Ascii,
                 ..Default::default()
             }),

--- a/modeling-cmds/src/format/mod.rs
+++ b/modeling-cmds/src/format/mod.rs
@@ -71,13 +71,17 @@ pub enum OutputFormat3d {
     Stl(stl::export::Options),
 }
 
+/// Alias for backward compatibility.
+#[deprecated(since = "0.2.96", note = "use `InputFormat3d` instead")]
+pub type InputFormat = InputFormat3d;
+
 /// Input format specifier.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[display(style = "snake_case")]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-pub enum InputFormat {
+pub enum InputFormat3d {
     /// Autodesk Filmbox (FBX) format.
     #[display("{}: {0}")]
     Fbx(fbx::import::Options),
@@ -228,30 +232,30 @@ impl From<FileExportFormat> for OutputFormat3d {
     }
 }
 
-impl From<InputFormat> for FileImportFormat {
-    fn from(input_format: InputFormat) -> Self {
+impl From<InputFormat3d> for FileImportFormat {
+    fn from(input_format: InputFormat3d) -> Self {
         match input_format {
-            InputFormat::Fbx(_) => Self::Fbx,
-            InputFormat::Gltf(_) => Self::Gltf,
-            InputFormat::Obj(_) => Self::Obj,
-            InputFormat::Ply(_) => Self::Ply,
-            InputFormat::Sldprt(_) => Self::Sldprt,
-            InputFormat::Step(_) => Self::Step,
-            InputFormat::Stl(_) => Self::Stl,
+            InputFormat3d::Fbx(_) => Self::Fbx,
+            InputFormat3d::Gltf(_) => Self::Gltf,
+            InputFormat3d::Obj(_) => Self::Obj,
+            InputFormat3d::Ply(_) => Self::Ply,
+            InputFormat3d::Sldprt(_) => Self::Sldprt,
+            InputFormat3d::Step(_) => Self::Step,
+            InputFormat3d::Stl(_) => Self::Stl,
         }
     }
 }
 
-impl From<FileImportFormat> for InputFormat {
+impl From<FileImportFormat> for InputFormat3d {
     fn from(import_format: FileImportFormat) -> Self {
         match import_format {
-            FileImportFormat::Fbx => InputFormat::Fbx(Default::default()),
-            FileImportFormat::Gltf => InputFormat::Gltf(Default::default()),
-            FileImportFormat::Obj => InputFormat::Obj(Default::default()),
-            FileImportFormat::Ply => InputFormat::Ply(Default::default()),
-            FileImportFormat::Sldprt => InputFormat::Sldprt(Default::default()),
-            FileImportFormat::Step => InputFormat::Step(Default::default()),
-            FileImportFormat::Stl => InputFormat::Stl(Default::default()),
+            FileImportFormat::Fbx => InputFormat3d::Fbx(Default::default()),
+            FileImportFormat::Gltf => InputFormat3d::Gltf(Default::default()),
+            FileImportFormat::Obj => InputFormat3d::Obj(Default::default()),
+            FileImportFormat::Ply => InputFormat3d::Ply(Default::default()),
+            FileImportFormat::Sldprt => InputFormat3d::Sldprt(Default::default()),
+            FileImportFormat::Step => InputFormat3d::Step(Default::default()),
+            FileImportFormat::Stl => InputFormat3d::Stl(Default::default()),
         }
     }
 }

--- a/modeling-cmds/src/format/mod.rs
+++ b/modeling-cmds/src/format/mod.rs
@@ -2,8 +2,10 @@ use parse_display_derive::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::shared::{FileExportFormat, FileImportFormat};
+use crate::shared::{FileExportFormat, FileExportFormat2d, FileImportFormat};
 
+/// AutoCAD drawing interchange format.
+pub mod dxf;
 /// Autodesk Filmbox (FBX) format.
 pub mod fbx;
 /// glTF 2.0.
@@ -23,7 +25,19 @@ pub mod stl;
 /// SolidWorks part (SLDPRT) format.
 pub mod sldprt;
 
-/// Output format specifier.
+/// Output 2D format specifier.
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[display(style = "snake_case")]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+pub enum OutputFormat2d {
+    /// AutoCAD drawing interchange format.
+    #[display("{}: {0}")]
+    Dxf(dxf::export::Options),
+}
+
+/// Output 3D format specifier.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Display, FromStr)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[display(style = "snake_case")]
@@ -167,6 +181,22 @@ impl From<OutputFormat> for FileExportFormat {
             OutputFormat::Ply(_) => Self::Ply,
             OutputFormat::Step(_) => Self::Step,
             OutputFormat::Stl(_) => Self::Stl,
+        }
+    }
+}
+
+impl From<OutputFormat2d> for FileExportFormat2d {
+    fn from(output_format: OutputFormat2d) -> Self {
+        match output_format {
+            OutputFormat2d::Dxf(_) => Self::Dxf,
+        }
+    }
+}
+
+impl From<FileExportFormat2d> for OutputFormat2d {
+    fn from(export_format: FileExportFormat2d) -> Self {
+        match export_format {
+            FileExportFormat2d::Dxf => OutputFormat2d::Dxf(Default::default()),
         }
     }
 }

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -293,12 +293,24 @@ define_ok_modeling_cmd_response_enum! {
         pub struct SelectClear {
         }
 
-        /// The response from the `Export` endpoint.
+        /// Alias for backward compatibility.
+        #[deprecated(since = "0.2.96", note = "use `Export3d` instead")]
+        pub type Export = Export3d;
+
+        /// The response from the `Export2d` endpoint.
         #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
-        pub struct Export {
+        pub struct Export2d {
             /// The files that were exported.
             pub files: Vec<ExportFile>,
         }
+
+        /// The response from the `Export3d` endpoint.
+        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        pub struct Export3d {
+            /// The files that were exported.
+            pub files: Vec<ExportFile>,
+        }
+
         /// The response from the `SelectWithPoint` command.
         #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
         pub struct SelectWithPoint {

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -622,6 +622,19 @@ pub enum FileExportFormat {
     Stl,
 }
 
+/// The valid types of 2D output file formats.
+#[derive(
+    Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Clone, Ord, PartialOrd, Sequence,
+)]
+#[serde(rename_all = "lowercase")]
+#[display(style = "lowercase")]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+pub enum FileExportFormat2d {
+    /// AutoCAD drawing interchange format.
+    Dxf,
+}
+
 /// The valid types of source file formats.
 #[derive(
     Display, FromStr, Copy, Eq, PartialEq, Debug, JsonSchema, Deserialize, Serialize, Clone, Ord, PartialOrd, Sequence,


### PR DESCRIPTION
There is no corresponding import 2D format yet. This is intended only as an export format from the engine. Conversions to/from DXF are not supported yet.