### PR TITLE
Add 'export' command back in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.99"
+version = "0.2.100"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.99"
+version = "0.2.100"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -326,10 +326,6 @@ define_modeling_cmd_enum! {
             pub magnitude: f32,
         }
 
-        /// Alias for backward compatibility.
-        #[deprecated(since = "0.2.96", note = "use `Export3d` instead")]
-        pub type Export = Export3d;
-
         /// Export a sketch to a file.
         #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
         #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
@@ -346,6 +342,17 @@ define_modeling_cmd_enum! {
         #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
         #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
         pub struct Export3d {
+            /// IDs of the entities to be exported. If this is empty, then all entities are exported.
+            pub entity_ids: Vec<Uuid>,
+            /// The file format to export to.
+            pub format: OutputFormat3d,
+        }
+
+        /// Export the scene to a file.
+        #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, ModelingCmdVariant)]
+        #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+        #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+        pub struct Export {
             /// IDs of the entities to be exported. If this is empty, then all entities are exported.
             pub entity_ids: Vec<Uuid>,
             /// The file format to export to.

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -293,10 +293,6 @@ define_ok_modeling_cmd_response_enum! {
         pub struct SelectClear {
         }
 
-        /// Alias for backward compatibility.
-        #[deprecated(since = "0.2.96", note = "use `Export3d` instead")]
-        pub type Export = Export3d;
-
         /// The response from the `Export2d` endpoint.
         #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
         pub struct Export2d {
@@ -307,6 +303,13 @@ define_ok_modeling_cmd_response_enum! {
         /// The response from the `Export3d` endpoint.
         #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
         pub struct Export3d {
+            /// The files that were exported.
+            pub files: Vec<ExportFile>,
+        }
+
+        /// The response from the `Export` endpoint.
+        #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
+        pub struct Export {
             /// The files that were exported.
             pub files: Vec<ExportFile>,
         }


### PR DESCRIPTION
Modeling app is still sending the Export command so Export2d and Export3d aren't going to be enough.