### PR TITLE
Use point types in CameraViewState

### DIFF
--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -773,8 +773,8 @@ pub enum WorldCoordinateSystem {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
 pub struct CameraViewState {
-    pub pivot_rotation: [f32; 4],
-    pub pivot_position: [f32; 3],
+    pub pivot_rotation: Quaternion,
+    pub pivot_position: Point3d,
     pub eye_offset: f32,
     pub fov_y: f32,
     pub ortho_scale_factor: f32,
@@ -786,14 +786,14 @@ pub struct CameraViewState {
 impl Default for CameraViewState {
     fn default() -> Self {
         CameraViewState {
-            pivot_rotation: [0.0, 0.0, 0.0, 1.0],
+            pivot_rotation: Default::default(),
             pivot_position: Default::default(),
             eye_offset: 10.0,
             fov_y: 45.0,
             ortho_scale_factor: 1.6,
             is_ortho: false,
             ortho_scale_enabled: true,
-            world_coord_system: WorldCoordinateSystem::default(),
+            world_coord_system: Default::default(),
         }
     }
 }

--- a/modeling-cmds/src/shared/point.rs
+++ b/modeling-cmds/src/shared/point.rs
@@ -7,6 +7,7 @@ mod uniform;
 mod zero;
 
 /// A point in 2D space
+#[repr(C)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, Default)]
 #[serde(rename = "Point2d")]
 #[serde(rename_all = "snake_case")]
@@ -55,6 +56,7 @@ impl<T> Point2d<T> {
 }
 
 /// A point in 3D space
+#[repr(C)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Default)]
 #[serde(rename = "Point3d")]
 #[serde(rename_all = "snake_case")]
@@ -114,6 +116,7 @@ impl<T> Point3d<T> {
 }
 
 /// A point in homogeneous (4D) space
+#[repr(C)]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "Point4d")]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
Switches fixed-size array members in `CameraViewState` to point types. Also adds C layout requirement to point types to allow passing over FFI boundaries.