### PR TITLE
Release modeling-cmds 0.2.116

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.115"
+version = "0.2.116"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.115"
+version = "0.2.116"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Added

* Fillet endpoint takes some new parameters:
  * strategy: users can choose between fast-but-fallible, or complex-but-comprehensive, or automatic (tries the fast strategy, and if that doesn't work, try the comprehensive strategy). Defaults to automatic.
  * edge_ids: this field replaces edge_id, and allows filleting multiple edges simultaneously.
  * extra_face_ids: if you sent multiple edge_ids, this array should contain the 2nd, 3rd, etc face ID for the resulting faces.

# Changed
 * In the fillet endpoint, `edge_id` is now optional and deprecated. To migrate, stop sending that field and instead send the single ID in `edge_ids`.