### PR TITLE
WIP: Add new "is_default_object" to MakePlane

### DIFF
--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -966,6 +966,9 @@ define_modeling_cmd_enum! {
             pub clobber: bool,
             /// If true, the plane will be created but hidden initially.
             pub hide: Option<bool>,
+            // If true, the plane is made a default object. Default objects like axis planes do not get
+            // included in scene bounding box calculations.
+            pub is_default_object: Option<bool>,
         }
 
         /// Set the color of a plane.


### PR DESCRIPTION
For https://github.com/KittyCAD/modeling-app/issues/6545

Adding a new param to be able to make new planes default objects - currently they are not which is causing bugs in bounding box calculation for `zoom_to_fit`