### PR TITLE
Run cargo sort, fix clippy lint

### DIFF
--- a/modeling-cmds-macros/Cargo.toml
+++ b/modeling-cmds-macros/Cargo.toml
@@ -8,6 +8,9 @@ description = "Macros for defining KittyCAD modeling commands"
 authors = ["Adam Chalmers"]
 keywords = ["kittycad"]
 license = "MIT"
+
+[lib]
+proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -15,9 +18,6 @@ kittycad-modeling-cmds-macros-impl = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true, features = ["extra-traits", "full"] }
-
-[lib]
-proc-macro = true
 
 [dev-dependencies]
 anyhow = "1.0.97"

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -8,6 +8,21 @@ rust-version = "1.74"
 repository = "https://github.com/KittyCAD/modeling-api"
 keywords = ["kittycad"]
 license = "MIT"
+
+[package.metadata.docs.rs]
+all-features = true
+
+[features]
+default = []
+derive-jsonschema-on-enums = []
+tabled = ["dep:tabled"]
+ts-rs = ["dep:ts-rs"]
+slog = ["dep:slog"]
+cxx = ["dep:cxx"]
+convert_client_crate = ["dep:kittycad"]
+websocket = ["dep:serde_json"]
+webrtc = ["dep:webrtc"]
+unstable_exhaustive = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -45,24 +60,9 @@ ts-rs = { version = "10.1.0", optional = true, features = [
 uuid = { version = "1.16.0", features = ["serde", "v4", "js"] }
 webrtc = { version = "0.12", optional = true }
 
-[lints]
-workspace = true
-
-[features]
-default = []
-derive-jsonschema-on-enums = []
-tabled = ["dep:tabled"]
-ts-rs = ["dep:ts-rs"]
-slog = ["dep:slog"]
-cxx = ["dep:cxx"]
-convert_client_crate = ["dep:kittycad"]
-websocket = ["dep:serde_json"]
-webrtc = ["dep:webrtc"]
-unstable_exhaustive = []
-
 [dev-dependencies]
 bson = "2.14.0"
 
-[package.metadata.docs.rs]
-all-features = true
+[lints]
+workspace = true
 

--- a/modeling-session/src/actor.rs
+++ b/modeling-session/src/actor.rs
@@ -124,6 +124,7 @@ pub async fn start(
 /// Given the text from a WebSocket, deserialize its JSON.
 /// Returns OK if the WebSocket's JSON represents a successful response.
 /// Returns an error if the WebSocket's JSON represented a failure response.
+#[allow(clippy::result_large_err)]
 fn decode_websocket_text(text: &str) -> Result<WebSocketResponse> {
     let resp = serde_json::from_str(text)?;
     Ok(resp)


### PR DESCRIPTION
Seems like cargo-sort 2.0 prefers a different sort order for the top-level sections like `[lib]` and `[features]`.