### PR TITLE
add optional origin for rotation transforms

### DIFF
--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -1100,7 +1100,8 @@ pub struct ComponentTransform {
     pub rotate_angle_axis: Option<TransformBy<Point4d<f64>>>,
     /// Scale component of the transform.
     pub scale: Option<TransformBy<Point3d<f64>>>,
-    /// Origin of the rotation.
+    /// Origin of the rotation. This will default to the world origin, [0, 0, 0].
+    #[serde(default)]
     pub origin: Option<TransformBy<Point3d<LengthUnit>>>,
 }
 

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -1100,6 +1100,8 @@ pub struct ComponentTransform {
     pub rotate_angle_axis: Option<TransformBy<Point4d<f64>>>,
     /// Scale component of the transform.
     pub scale: Option<TransformBy<Point3d<f64>>>,
+    /// Origin of the rotation.
+    pub origin: Option<TransformBy<Point3d<LengthUnit>>>,
 }
 
 ///If bidirectional or symmetric operations are needed this enum encapsulates the required


### PR DESCRIPTION
Allow an origin of rotation to be specified when applying a rotate transform. If null, will use [0, 0, 0]