### PR TITLE
Bump ts-rs from 10.1.0 to 11.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,12 +4492,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ts-rs"
-version = "10.1.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e640d9b0964e9d39df633548591090ab92f7a4567bc31d3891af23471a3365c6"
+checksum = "6ef1b7a6d914a34127ed8e1fa927eb7088903787bcded4fa3eef8f85ee1568be"
 dependencies = [
  "chrono",
- "lazy_static",
  "serde_json",
  "thiserror 2.0.12",
  "ts-rs-macros",
@@ -4506,9 +4505,9 @@ dependencies = [
 
 [[package]]
 name = "ts-rs-macros"
-version = "10.1.0"
+version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9d8656589772eeec2cf7a8264d9cda40fb28b9bc53118ceb9e8c07f8f38730"
+checksum = "e9d4ed7b4c18cc150a6a0a1e9ea1ecfa688791220781af6e119f9599a8502a0a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -51,7 +51,7 @@ serde_bytes = "0.11.17"
 serde_json = { version = "1.0.139", optional = true }
 slog = { version = "2.7.0", optional = true }
 tabled = { version = "0.18", optional = true }
-ts-rs = { version = "10.1.0", optional = true, features = [
+ts-rs = { version = "11.0.1", optional = true, features = [
 	"chrono-impl",
     "uuid-impl",
     "no-serde-warnings",


### PR DESCRIPTION
This is a breaking change for anything that uses the `ts-rs` feature.