### PR TITLE
Change from f32 to f64 for `duration_seconds`

### DIFF
--- a/modeling-cmds-macros-impl/benches/my_benchmark.rs
+++ b/modeling-cmds-macros-impl/benches/my_benchmark.rs
@@ -27,7 +27,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             };
 
             /// Mike says this usually looks nice.
-            fn default_animation_seconds() -> f32 {
+            fn default_animation_seconds() -> f64 {
                 0.4
             }
 
@@ -660,7 +660,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 pub fade_in: bool,
                 /// How many seconds the animation should take.
                 #[serde(default = "default_animation_seconds")]
-                pub duration_seconds: f32,
+                pub duration_seconds: f64,
             }
 
             /// Make a new plane

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -37,7 +37,7 @@ define_modeling_cmd_enum! {
         };
 
         /// Mike says this usually looks nice.
-        fn default_animation_seconds() -> f32 {
+        fn default_animation_seconds() -> f64 {
             0.4
         }
 
@@ -980,7 +980,7 @@ define_modeling_cmd_enum! {
             pub fade_in: bool,
             /// How many seconds the animation should take.
             #[serde(default = "default_animation_seconds")]
-            pub duration_seconds: f32,
+            pub duration_seconds: f64,
         }
 
         /// Make a new plane


### PR DESCRIPTION
Elsewhere in the OpenAPI spec this is (implicitly?) turned into a f64. Due to a long string of things I talk often about, this changes the represntation enough to change the value from 0.4 to 0.4000000059604645

Don't believe me? See for yourself!

```rust
fn main() {
    let x: f64 = (0.4 as f32) as f64;
    eprintln!("{:?}", x)
}
```

This, even more hilariously, shows up in the OpenAPI spec:

```sh
$ curl https://api.zoo.dev/ \
  | jq '.components.schemas.ModelingCmd.oneOf[] | select(.description | contains("Fade entity in or out.")).properties.duration_seconds'
{
  "default": 0.4000000059604645,
  "description": "How many seconds the animation should take.",
  "format": "float",
  "type": "number"
}
```

This changes the default to f64 which doesn't appear to break anything i've built locally -- although I haven't been able to pull this all the way through due to other upgrade-path issues.

That being said this is a pretty easy one to fix (or revert) if it causes issues.