### PR TITLE
Expose Extrude Method

### DIFF
--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -123,6 +123,9 @@ define_modeling_cmd_enum! {
             /// If so, this specifies its distance.
             #[serde(default)]
             pub opposite: Opposite<LengthUnit>,
+            /// Should the extrusion create a new object or be part of the existing object.
+            #[serde(default)]
+            pub new_object: bool,
         }
 
         fn default_twist_extrude_section_interval() -> Angle {

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -123,7 +123,8 @@ define_modeling_cmd_enum! {
             /// If so, this specifies its distance.
             #[serde(default)]
             pub opposite: Opposite<LengthUnit>,
-            /// Should the extrusion create a new object or be part of the existing object.
+            /// Should the extrusion create a new object or be part of the existing object. If a
+            /// new object is created, the command id will be the id of the newly created object.
             #[serde(default)]
             pub extrude_method: ExtrudeMethod,
         }

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -28,7 +28,7 @@ define_modeling_cmd_enum! {
                 CutType,
                 CutStrategy,
                 CameraMovement,
-                ExtrudedFaceInfo,
+                ExtrudedFaceInfo, ExtrudeMethod,
                 AnnotationOptions, AnnotationType, CameraDragInteractionType, Color, DistanceType, EntityType,
                 PathComponentConstraintBound, PathComponentConstraintType, PathSegment, PerspectiveCameraParameters,
                 Point2d, Point3d, SceneSelectionType, SceneToolType, Opposite,
@@ -125,7 +125,7 @@ define_modeling_cmd_enum! {
             pub opposite: Opposite<LengthUnit>,
             /// Should the extrusion create a new object or be part of the existing object.
             #[serde(default)]
-            pub new_object: bool,
+            pub extrude_method: ExtrudeMethod,
         }
 
         fn default_twist_extrude_section_interval() -> Angle {

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -741,7 +741,7 @@ pub enum ExtrudeMethod {
     /// This extrusion will be part of object it is extruded from. This will result in one object
     /// after the operation.
     #[default]
-    Add,
+    Merge,
 }
 
 /// IDs for the extruded faces.

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -736,7 +736,7 @@ impl From<EngineErrorCode> for http::StatusCode {
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
 pub enum ExtrudeMethod {
     /// Create a new object that is not connected to the object it is extruded from. This will
-    /// result in two objects after the opreration.
+    /// result in two objects after the operation.
     New,
     /// This extrusion will be part of object it is extruded from. This will result in one object
     /// after the operation.

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -730,7 +730,8 @@ impl From<EngineErrorCode> for http::StatusCode {
 
 /// Extrusion method determining if the extrusion will be part of the existing object or an
 /// entirely new object.
-#[derive(Debug, PartialEq, Serialize, Deserialize, JsonSchema, Clone, Default)]
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
 pub enum ExtrudeMethod {

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -728,6 +728,21 @@ impl From<EngineErrorCode> for http::StatusCode {
     }
 }
 
+/// Extrusion method determining if the extrusion will be part of the existing object or an
+/// entirely new object.
+#[derive(Debug, PartialEq, Serialize, Deserialize, JsonSchema, Clone, Default)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+pub enum ExtrudeMethod {
+    /// Create a new object that is not connected to the object it is extruded from. This will
+    /// result in two objects after the opreration.
+    New,
+    /// This extrusion will be part of object it is extruded from. This will result in one object
+    /// after the operation.
+    #[default]
+    Add,
+}
+
 /// IDs for the extruded faces.
 #[derive(Debug, PartialEq, Serialize, Deserialize, JsonSchema, Clone)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]

--- a/modeling-session/examples/cube_png.rs
+++ b/modeling-session/examples/cube_png.rs
@@ -109,6 +109,7 @@ async fn main() -> Result<()> {
                 target: path,
                 faces: None,
                 opposite: Default::default(),
+                extrude_method: Default::default(),
             }
             .into(),
         )

--- a/modeling-session/examples/cube_png_batch.rs
+++ b/modeling-session/examples/cube_png_batch.rs
@@ -100,6 +100,7 @@ async fn main() -> Result<()> {
             target: path,
             faces: None,
             opposite: Default::default(),
+            extrude_method: Default::default(),
         }),
         cmd_id: random_id(),
     });

--- a/modeling-session/examples/lsystem_png_batch.rs
+++ b/modeling-session/examples/lsystem_png_batch.rs
@@ -139,6 +139,7 @@ async fn main() -> Result<()> {
             target: path,
             faces: None,
             opposite: Default::default(),
+            extrude_method: Default::default(),
         }),
         cmd_id: random_id(),
     });


### PR DESCRIPTION
The result of an extrude currently cuts the face of the object and returns one object. It can be made to instead be a separate object entirely. This new argument exposes that option