### PR TITLE
Release modeling-cmds 0.2.127

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.126"
+version = "0.2.127"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.126"
+version = "0.2.127"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Added

* The `extrude` endpoint now takes an additional field `extrude_method: ExtrudeMethod`. It defaults to `ExtrudeMethod::Merge` which was the current, default behaviour. If your extruded sketch is sketched on the face of some solid, this tells the engine to pull it out of the solid (or push it into), i.e. modifying the original solid geometry. You can now set `ExtrudeMethod::New` which creates a new solid, leaving the original solid as it was. (#905)

# Fixed

* Some typos in documentation