### PR TITLE
remove incorrect comment from api

### DIFF
--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -123,8 +123,7 @@ define_modeling_cmd_enum! {
             /// If so, this specifies its distance.
             #[serde(default)]
             pub opposite: Opposite<LengthUnit>,
-            /// Should the extrusion create a new object or be part of the existing object. If a
-            /// new object is created, the command id will be the id of the newly created object.
+            /// Should the extrusion create a new object or be part of the existing object.
             #[serde(default)]
             pub extrude_method: ExtrudeMethod,
         }


### PR DESCRIPTION
For extrude method the comment regarding the id of the new object is incorrect and has been removed.