### PR TITLE
Release modeling-cmds 0.2.129

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.128"
+version = "0.2.129"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.128"
+version = "0.2.129"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
## Added

 - Optional python support, behind the feature `python` (#913)