### PR TITLE
Bring angle units inline with length units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.133"
+version = "0.2.134"
 dependencies = [
  "anyhow",
  "bson",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.133"
+version = "0.2.134"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"

--- a/modeling-cmds/src/units.rs
+++ b/modeling-cmds/src/units.rs
@@ -70,6 +70,7 @@ impl UnitLength {
 
 /// The valid types of angle formats.
 #[derive(
+    Default,
     Display,
     FromStr,
     Copy,
@@ -83,6 +84,7 @@ impl UnitLength {
     Ord,
     PartialOrd,
     UnitConversion,
+    Hash,
 )]
 #[cfg_attr(feature = "tabled", derive(tabled::Tabled))]
 #[serde(rename_all = "snake_case")]
@@ -92,8 +94,13 @@ impl UnitLength {
 #[cfg_attr(feature = "python", pyo3::pyclass, pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
 pub enum UnitAngle {
     /// Degrees <https://en.wikipedia.org/wiki/Degree_(angle)>
+    #[default]
+    #[serde(rename = "deg")]
+    #[display("deg")]
     Degrees,
     /// Radians <https://en.wikipedia.org/wiki/Radian>
+    #[serde(rename = "rad")]
+    #[display("rad")]
     Radians,
 }
 


### PR DESCRIPTION
Use shorthand versions of the angle units (deg and rad) in the same way as length units so that we can use the units enum in the modelling app. Also adds default and hash impls.