### PR TITLE
make length optional in helixes

### DIFF
--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -590,8 +590,8 @@ define_modeling_cmd_enum! {
             pub start_angle: Angle,
             /// Is the helix rotation clockwise?
             pub is_clockwise: bool,
-            /// Length of the helix.
-            pub length: LengthUnit,
+            /// Length of the helix. If None, the length of the cylinder will be used instead.
+            pub length: Option<LengthUnit>,
         }
 
         /// Create a helix using the specified parameters.


### PR DESCRIPTION
This is part of the effort in https://github.com/KittyCAD/modeling-app/pull/8219 .

It allows for the removal of a field from the Solid struct on the frontend, and cleans up the api and documentation to match the engine's actual behavior