### PR TITLE
refactor(modeling-cmds)!: label optional, dupes now fail

### DIFF
--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -101,8 +101,8 @@ define_modeling_cmd_enum! {
             /// This segment will implicitly begin at the current "pen" location.
             pub segment: PathSegment,
             /// Optional label to associate with the new path segment.
-            #[serde(default, skip_serializing_if = "String::is_empty")]
-            pub label: String,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub label:Option< String>,
         }
 
         /// Command for extruding a solid 2d.
@@ -140,7 +140,7 @@ define_modeling_cmd_enum! {
             /// Which sketch to extrude.
             /// Must be a closed 2D solid.
             pub target: ModelingCmdId,
-            /// Reference to extrude to. 
+            /// Reference to extrude to.
             /// Extrusion occurs along the target's normal until it is as close to the reference as possible.
             pub reference: ExtrudeReference,
             /// Which IDs should the new faces have?

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -102,7 +102,7 @@ define_modeling_cmd_enum! {
             pub segment: PathSegment,
             /// Optional label to associate with the new path segment.
             #[serde(default, skip_serializing_if = "Option::is_none")]
-            pub label:Option< String>,
+            pub label: Option<String>,
         }
 
         /// Command for extruding a solid 2d.

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -766,7 +766,7 @@ pub enum ExtrudeMethod {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
 pub enum ExtrudeReference {
-    /// Extrudes along the normal of the top face until it is as close to the entity as possible. 
+    /// Extrudes along the normal of the top face until it is as close to the entity as possible.
     /// An entity can be a solid, a path, a face, etc.
     EntityReference {
         /// The UUID of the entity to extrude to.
@@ -785,7 +785,7 @@ pub enum ExtrudeReference {
     Point {
         /// The point to extrude to.
         point: Point3d<LengthUnit>,
-    }
+    },
 }
 
 /// IDs for the extruded faces.

--- a/modeling-cmds/tests/python_stub_dupes.rs
+++ b/modeling-cmds/tests/python_stub_dupes.rs
@@ -37,8 +37,6 @@ fn print_duplicate_stub_names() {
         .map(|(n, c)| (n.to_string(), c))
         .collect();
 
-    eprintln!("duplicate classes: {:?}", dup_classes);
-    eprintln!("duplicate enums: {:?}", dup_enums);
-
-    // This is informational; do not fail test. If we decide to enforce, we can assert emptiness.
+    assert!(dup_classes.is_empty(), "Duplicate class names: {dup_classes:?}");
+    assert!(dup_enums.is_empty(), "Duplicate enum names: {dup_enums:?}");
 }


### PR DESCRIPTION
- label becomes Option<String> instead of empty String, serde updated, this is just more consistent w the rest of the api
- test now asserts duplicate Python stub class and enum names