### PR TITLE
Revert "Custom chamfer profiles (#938)"

### DIFF
--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -11,59 +11,17 @@ use crate::{length_unit::LengthUnit, output::ExtrusionFaceInfo, units::UnitAngle
 
 mod point;
 
-/// Params required to perform a fillet cut of an edge.
+/// What kind of cut to do
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-pub struct FilletParams {
-    /// The second length affects the edge length of the second face of the cut. This will
-    /// cause the fillet to take on the shape of a conic section, instead of an arc.
-    pub second_length: Option<LengthUnit>,
-}
-
-/// Params required to perform a chamfer cut of an edge.
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
-#[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-pub struct ChamferParams {
-    /// The second length affects the edge length of the second face of the cut.
-    pub second_length: Option<LengthUnit>,
-    /// The angle of the chamfer, default is 45deg.
-    pub angle: Option<Angle>,
-    /// If true, the second length or angle is applied to the other face of the cut.
-    pub swap: bool,
-}
-
-/// Params required to perform a custom profile cut of an edge.
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-pub struct CustomParams {
-    /// The path that will be used for the custom profile.
-    pub path: Uuid,
-}
-
-/// What kind of cut to perform when cutting an edge.
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
 pub enum CutType {
     /// Round off an edge.
-    Fillet(FilletParams),
+    #[default]
+    Fillet,
     /// Cut away an edge.
-    Chamfer(ChamferParams),
-    /// A custom cut profile.
-    Custom(CustomParams),
-}
-
-impl Default for CutType {
-    fn default() -> Self {
-        crate::shared::CutType::Fillet(FilletParams::default())
-    }
+    Chamfer,
 }
 
 /// A rotation defined by an axis, origin of rotation, and an angle.


### PR DESCRIPTION
This reverts commit aa231cc08603805e8782656063bcbcb7c6579812.

This is causing an "invalid type: unit variant. expected newtype variant" error. I suspect it's a deserialization problem.