### PR TITLE
Non-destructive, partial surface extrudes/revolves/sweeps etc

### DIFF
--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -2288,6 +2288,11 @@
                   }
                 ]
               },
+              "keep_seams": {
+                "description": "When two collinear segments are extruded, what should happen? If true, creates a body with two separate surfaces. If false, creates a body with one surface, spanning both collinear segments.",
+                "default": false,
+                "type": "boolean"
+              },
               "merge_coplanar_faces": {
                 "nullable": true,
                 "description": "Only used if the extrusion is created from a face and extrude_method = Merge If true, coplanar faces will be merged and seams will be hidden. Otherwise, seams between the extrusion and original body will be shown.",
@@ -2302,8 +2307,17 @@
                   }
                 ]
               },
+              "segments": {
+                "nullable": true,
+                "description": "If given, extrude each of these segments into a separate body with the given ID.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
               "target": {
-                "description": "Which sketch to extrude. Must be a closed 2D solid.",
+                "description": "Which sketch to extrude. Must be a 2D sketch.",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/ModelingCmdId"
@@ -2355,6 +2369,11 @@
                   }
                 ]
               },
+              "keep_seams": {
+                "description": "When two collinear segments are extruded, what should happen? If true, creates a body with two surfaces. If false, creates a body with one surface, spanning both collinear segments.",
+                "default": false,
+                "type": "boolean"
+              },
               "reference": {
                 "description": "Reference to extrude to. Extrusion occurs along the target's normal until it is as close to the reference as possible.",
                 "allOf": [
@@ -2362,6 +2381,15 @@
                     "$ref": "#/components/schemas/ExtrudeReference"
                   }
                 ]
+              },
+              "segments": {
+                "nullable": true,
+                "description": "If given, extrude each of these segments into a separate body with the given ID.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
               },
               "target": {
                 "description": "Which sketch to extrude. Must be a closed 2D solid.",
@@ -2439,6 +2467,20 @@
                   }
                 ]
               },
+              "keep_seams": {
+                "description": "When two collinear segments are extruded, what should happen? If true, creates a body with two surfaces. If false, creates a body with one surface, spanning both collinear segments.",
+                "default": false,
+                "type": "boolean"
+              },
+              "segments": {
+                "nullable": true,
+                "description": "If given, extrude each of these segments into a separate body with the given ID.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
               "target": {
                 "description": "Which sketch to extrude. Must be a closed 2D solid.",
                 "allOf": [
@@ -2491,6 +2533,11 @@
                   }
                 ]
               },
+              "keep_seams": {
+                "description": "When two collinear segments are extruded, what should happen? If true, creates a body with two surfaces. If false, creates a body with one surface, spanning both collinear segments.",
+                "default": false,
+                "type": "boolean"
+              },
               "relative_to": {
                 "description": "What is this sweep relative to?",
                 "default": "sketch_plane",
@@ -2503,6 +2550,15 @@
               "sectional": {
                 "description": "If true, the sweep will be broken up into sub-sweeps (extrusions, revolves, sweeps) based on the trajectory path components.",
                 "type": "boolean"
+              },
+              "segments": {
+                "nullable": true,
+                "description": "If given, extrude each of these segments into a separate body with the given ID.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
               },
               "target": {
                 "description": "Which sketch to sweep. Must be a closed 2D solid.",
@@ -2583,6 +2639,11 @@
                   }
                 ]
               },
+              "keep_seams": {
+                "description": "When two collinear segments are extruded, what should happen? If true, creates a body with two surfaces. If false, creates a body with one surface, spanning both collinear segments.",
+                "default": false,
+                "type": "boolean"
+              },
               "opposite": {
                 "description": "Should the revolution also revolve in the opposite direction along the given axis? If so, this specifies its angle.",
                 "default": "None",
@@ -2599,6 +2660,15 @@
                     "$ref": "#/components/schemas/Point3d"
                   }
                 ]
+              },
+              "segments": {
+                "nullable": true,
+                "description": "If given, extrude each of these segments into a separate body with the given ID.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
               },
               "target": {
                 "description": "Which sketch to revolve. Must be a closed 2D solid.",
@@ -2869,6 +2939,7 @@
                 "type": "string",
                 "format": "uuid"
               },
+<<<<<<< HEAD
               "edge_reference": {
                 "nullable": true,
                 "description": "Edge reference to use as the axis of revolution (new API). If both `edge_id` and `edge_reference` are provided, `edge_reference` takes precedence.",
@@ -2877,6 +2948,13 @@
                     "$ref": "#/components/schemas/EdgeSpecifier"
                   }
                 ]
+||||||| parent of 3cb4bff (Configurable seams)
+=======
+              "keep_seams": {
+                "description": "When two collinear segments are extruded, what should happen? If true, creates a body with two surfaces. If false, creates a body with one surface, spanning both collinear segments.",
+                "default": false,
+                "type": "boolean"
+>>>>>>> 3cb4bff (Configurable seams)
               },
               "opposite": {
                 "description": "Should the revolution also revolve in the opposite direction along the given axis? If so, this specifies its angle.",
@@ -2886,6 +2964,15 @@
                     "$ref": "#/components/schemas/OppositeForAngle"
                   }
                 ]
+              },
+              "segments": {
+                "nullable": true,
+                "description": "If given, extrude each of these segments into a separate body with the given ID.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
               },
               "target": {
                 "description": "Which sketch to revolve. Must be a closed 2D solid.",

--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -2939,7 +2939,6 @@
                 "type": "string",
                 "format": "uuid"
               },
-<<<<<<< HEAD
               "edge_reference": {
                 "nullable": true,
                 "description": "Edge reference to use as the axis of revolution (new API). If both `edge_id` and `edge_reference` are provided, `edge_reference` takes precedence.",
@@ -2948,13 +2947,11 @@
                     "$ref": "#/components/schemas/EdgeSpecifier"
                   }
                 ]
-||||||| parent of 3cb4bff (Configurable seams)
-=======
+              },
               "keep_seams": {
                 "description": "When two collinear segments are extruded, what should happen? If true, creates a body with two surfaces. If false, creates a body with one surface, spanning both collinear segments.",
                 "default": false,
                 "type": "boolean"
->>>>>>> 3cb4bff (Configurable seams)
               },
               "opposite": {
                 "description": "Should the revolution also revolve in the opposite direction along the given axis? If so, this specifies its angle.",

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -128,8 +128,17 @@ define_modeling_cmd_enum! {
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct Extrude {
             /// Which sketch to extrude.
-            /// Must be a closed 2D solid.
+            /// Must be a 2D sketch.
             pub target: ModelingCmdId,
+            /// If given, extrude each of these segments into a separate body with the given ID.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub segments: Option<Vec<Uuid>>,
+            /// When two collinear segments are extruded, what should happen?
+            /// If true, creates a body with two separate surfaces.
+            /// If false, creates a body with one surface, spanning both collinear segments.
+            #[serde(default)]
+            #[builder(default)]
+            pub keep_seams: bool,
             /// How far off the plane to extrude
             pub distance: LengthUnit,
             /// Which IDs should the new faces have?
@@ -169,6 +178,15 @@ define_modeling_cmd_enum! {
             /// Which sketch to extrude.
             /// Must be a closed 2D solid.
             pub target: ModelingCmdId,
+            /// If given, extrude each of these segments into a separate body with the given ID.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub segments: Option<Vec<Uuid>>,
+            /// When two collinear segments are extruded, what should happen?
+            /// If true, creates a body with two surfaces.
+            /// If false, creates a body with one surface, spanning both collinear segments.
+            #[serde(default)]
+            #[builder(default)]
+            pub keep_seams: bool,
             /// Reference to extrude to.
             /// Extrusion occurs along the target's normal until it is as close to the reference as possible.
             pub reference: ExtrudeReference,
@@ -202,6 +220,15 @@ define_modeling_cmd_enum! {
             /// Which sketch to extrude.
             /// Must be a closed 2D solid.
             pub target: ModelingCmdId,
+            /// If given, extrude each of these segments into a separate body with the given ID.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub segments: Option<Vec<Uuid>>,
+            /// When two collinear segments are extruded, what should happen?
+            /// If true, creates a body with two surfaces.
+            /// If false, creates a body with one surface, spanning both collinear segments.
+            #[serde(default)]
+            #[builder(default)]
+            pub keep_seams: bool,
             /// How far off the plane to extrude
             pub distance: LengthUnit,
             /// Which IDs should the new faces have?
@@ -239,6 +266,15 @@ define_modeling_cmd_enum! {
             /// Which sketch to sweep.
             /// Must be a closed 2D solid.
             pub target: ModelingCmdId,
+            /// If given, extrude each of these segments into a separate body with the given ID.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub segments: Option<Vec<Uuid>>,
+            /// When two collinear segments are extruded, what should happen?
+            /// If true, creates a body with two surfaces.
+            /// If false, creates a body with one surface, spanning both collinear segments.
+            #[serde(default)]
+            #[builder(default)]
+            pub keep_seams: bool,
             /// Path along which to sweep.
             pub trajectory: ModelingCmdId,
             /// If true, the sweep will be broken up into sub-sweeps (extrusions, revolves, sweeps) based on the trajectory path components.
@@ -271,6 +307,15 @@ define_modeling_cmd_enum! {
             /// Which sketch to revolve.
             /// Must be a closed 2D solid.
             pub target: ModelingCmdId,
+            /// If given, extrude each of these segments into a separate body with the given ID.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub segments: Option<Vec<Uuid>>,
+            /// When two collinear segments are extruded, what should happen?
+            /// If true, creates a body with two surfaces.
+            /// If false, creates a body with one surface, spanning both collinear segments.
+            #[serde(default)]
+            #[builder(default)]
+            pub keep_seams: bool,
             /// The origin of the extrusion axis
             pub origin: Point3d<LengthUnit>,
             /// The axis of the extrusion (taken from the origin)
@@ -422,6 +467,15 @@ define_modeling_cmd_enum! {
             /// Which sketch to revolve.
             /// Must be a closed 2D solid.
             pub target: ModelingCmdId,
+            /// If given, extrude each of these segments into a separate body with the given ID.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub segments: Option<Vec<Uuid>>,
+            /// When two collinear segments are extruded, what should happen?
+            /// If true, creates a body with two surfaces.
+            /// If false, creates a body with one surface, spanning both collinear segments.
+            #[serde(default)]
+            #[builder(default)]
+            pub keep_seams: bool,
             /// The edge to use as the axis of revolution, must be linear and lie in the plane of the solid
             #[serde(default, skip_serializing_if = "Option::is_none")]
             pub edge_id: Option<Uuid>,

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -24,7 +24,7 @@ define_ok_modeling_cmd_response_enum! {
             base64::Base64Data,
             id::ModelingCmdId,
             length_unit::LengthUnit,
-            shared::{CurveType, EntityType, ExportFile, ExtrusionFaceCapType, PathCommand, Point2d, Point3d, BodiesCreated},
+            shared::{CurveType, EntityType, ExportFile, ExtrusionFaceCapType, PathCommand, Point2d, Point3d, BodiesCreated, BodiesUpdated},
             units,
         };
 
@@ -59,7 +59,11 @@ define_ok_modeling_cmd_response_enum! {
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct Extrude {
             /// Any new bodies created by the request.
-            pub bodies: BodiesCreated,
+            #[serde(default, skip_serializing_if = "BodiesCreated::is_empty")]
+            pub bodies_created: BodiesCreated,
+            /// Any existing bodies updated by the request.
+            #[serde(default, skip_serializing_if = "BodiesUpdated::is_empty")]
+            pub bodies_updated: BodiesUpdated,
         }
 
         /// The response from the `ExtrudeToReference` endpoint.
@@ -67,7 +71,11 @@ define_ok_modeling_cmd_response_enum! {
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct ExtrudeToReference {
             /// Any new bodies created by the request.
-            pub bodies: BodiesCreated,
+            #[serde(default, skip_serializing_if = "BodiesCreated::is_empty")]
+            pub bodies_created: BodiesCreated,
+            /// Any existing bodies updated by the request.
+            #[serde(default, skip_serializing_if = "BodiesUpdated::is_empty")]
+            pub bodies: BodiesUpdated,
         }
 
         /// The response from the `TwistExtrude` endpoint.
@@ -75,7 +83,11 @@ define_ok_modeling_cmd_response_enum! {
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct TwistExtrude {
             /// Any new bodies created by the request.
-            pub bodies: BodiesCreated,
+            #[serde(default, skip_serializing_if = "BodiesCreated::is_empty")]
+            pub bodies_created: BodiesCreated,
+            /// Any existing bodies updated by the request.
+            #[serde(default, skip_serializing_if = "BodiesUpdated::is_empty")]
+            pub bodies: BodiesUpdated,
         }
 
         /// The response from the `Sweep` endpoint.
@@ -83,7 +95,11 @@ define_ok_modeling_cmd_response_enum! {
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct Sweep {
             /// Any new bodies created by the request.
-            pub bodies: BodiesCreated,
+            #[serde(default, skip_serializing_if = "BodiesCreated::is_empty")]
+            pub bodies_created: BodiesCreated,
+            /// Any existing bodies updated by the request.
+            #[serde(default, skip_serializing_if = "BodiesUpdated::is_empty")]
+            pub bodies: BodiesUpdated,
         }
 
         /// The response from the `Revolve` endpoint.
@@ -91,7 +107,11 @@ define_ok_modeling_cmd_response_enum! {
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct Revolve {
             /// Any new bodies created by the request.
-            pub bodies: BodiesCreated,
+            #[serde(default, skip_serializing_if = "BodiesCreated::is_empty")]
+            pub bodies_created: BodiesCreated,
+            /// Any existing bodies updated by the request.
+            #[serde(default, skip_serializing_if = "BodiesUpdated::is_empty")]
+            pub bodies: BodiesUpdated,
         }
 
         /// The response from the `Solid3dShellFace` endpoint.
@@ -146,7 +166,11 @@ define_ok_modeling_cmd_response_enum! {
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct RevolveAboutEdge {
             /// Any new bodies created by the request.
-            pub bodies: BodiesCreated,
+            #[serde(default, skip_serializing_if = "BodiesCreated::is_empty")]
+            pub bodies_created: BodiesCreated,
+            /// Any existing bodies updated by the request.
+            #[serde(default, skip_serializing_if = "BodiesUpdated::is_empty")]
+            pub bodies: BodiesUpdated,
         }
 
         /// The response from the `CameraDragStart` endpoint.

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -74,7 +74,7 @@ define_ok_modeling_cmd_response_enum! {
             pub bodies_created: BodiesCreated,
             /// Any existing bodies updated by the request.
             #[serde(default, skip_serializing_if = "BodiesUpdated::is_empty")]
-            pub bodies: BodiesUpdated,
+            pub bodies_updated: BodiesUpdated,
         }
 
         /// The response from the `TwistExtrude` endpoint.
@@ -86,7 +86,7 @@ define_ok_modeling_cmd_response_enum! {
             pub bodies_created: BodiesCreated,
             /// Any existing bodies updated by the request.
             #[serde(default, skip_serializing_if = "BodiesUpdated::is_empty")]
-            pub bodies: BodiesUpdated,
+            pub bodies_updated: BodiesUpdated,
         }
 
         /// The response from the `Sweep` endpoint.
@@ -98,7 +98,7 @@ define_ok_modeling_cmd_response_enum! {
             pub bodies_created: BodiesCreated,
             /// Any existing bodies updated by the request.
             #[serde(default, skip_serializing_if = "BodiesUpdated::is_empty")]
-            pub bodies: BodiesUpdated,
+            pub bodies_updated: BodiesUpdated,
         }
 
         /// The response from the `Revolve` endpoint.
@@ -110,7 +110,7 @@ define_ok_modeling_cmd_response_enum! {
             pub bodies_created: BodiesCreated,
             /// Any existing bodies updated by the request.
             #[serde(default, skip_serializing_if = "BodiesUpdated::is_empty")]
-            pub bodies: BodiesUpdated,
+            pub bodies_updated: BodiesUpdated,
         }
 
         /// The response from the `Solid3dShellFace` endpoint.

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -169,7 +169,7 @@ define_ok_modeling_cmd_response_enum! {
             pub bodies_created: BodiesCreated,
             /// Any existing bodies updated by the request.
             #[serde(default, skip_serializing_if = "BodiesUpdated::is_empty")]
-            pub bodies: BodiesUpdated,
+            pub bodies_updated: BodiesUpdated,
         }
 
         /// The response from the `CameraDragStart` endpoint.

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -24,7 +24,7 @@ define_ok_modeling_cmd_response_enum! {
             base64::Base64Data,
             id::ModelingCmdId,
             length_unit::LengthUnit,
-            shared::{CurveType, EntityType, ExportFile, ExtrusionFaceCapType, PathCommand, Point2d, Point3d},
+            shared::{CurveType, EntityType, ExportFile, ExtrusionFaceCapType, PathCommand, Point2d, Point3d, BodiesCreated},
             units,
         };
 
@@ -58,30 +58,40 @@ define_ok_modeling_cmd_response_enum! {
         #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct Extrude {
+            /// Any new bodies created by the request.
+            pub bodies: BodiesCreated,
         }
 
         /// The response from the `ExtrudeToReference` endpoint.
         #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct ExtrudeToReference {
+            /// Any new bodies created by the request.
+            pub bodies: BodiesCreated,
         }
 
         /// The response from the `TwistExtrude` endpoint.
         #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct TwistExtrude {
+            /// Any new bodies created by the request.
+            pub bodies: BodiesCreated,
         }
 
         /// The response from the `Sweep` endpoint.
         #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct Sweep {
+            /// Any new bodies created by the request.
+            pub bodies: BodiesCreated,
         }
 
         /// The response from the `Revolve` endpoint.
         #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct Revolve {
+            /// Any new bodies created by the request.
+            pub bodies: BodiesCreated,
         }
 
         /// The response from the `Solid3dShellFace` endpoint.
@@ -135,6 +145,8 @@ define_ok_modeling_cmd_response_enum! {
         #[derive(Debug, Serialize, Deserialize, Clone, JsonSchema, ModelingCmdOutput)]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct RevolveAboutEdge {
+            /// Any new bodies created by the request.
+            pub bodies: BodiesCreated,
         }
 
         /// The response from the `CameraDragStart` endpoint.

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -1862,6 +1862,18 @@ impl From<BodyUpdated> for BodyCreated {
     }
 }
 
+impl From<BodiesCreated> for BodiesUpdated {
+    fn from(bodies: BodiesCreated) -> Self {
+        Self { bodies: bodies.bodies.into_iter().map(Into::into).collect() }
+    }
+}
+
+impl From<BodiesUpdated> for BodiesCreated {
+    fn from(bodies: BodiesUpdated) -> Self {
+        Self { bodies: bodies.bodies.into_iter().map(Into::into).collect() }
+    }
+}
+
 fn one() -> f32 {
     1.0
 }

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -1911,7 +1911,7 @@ pub struct SurfaceEdgeReference {
 }
 
 /// List of bodies that were created by an operation.
-#[derive(Builder, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Builder, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
@@ -1919,6 +1919,31 @@ pub struct SurfaceEdgeReference {
 pub struct BodiesCreated {
     /// All bodies created by this operation.
     pub bodies: Vec<BodyCreated>,
+}
+
+impl BodiesCreated {
+    /// Are there any bodies in this list?
+    pub fn is_empty(&self) -> bool {
+        self.bodies.is_empty()
+    }
+}
+
+/// List of bodies that were updated by an operation.
+#[derive(Builder, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+pub struct BodiesUpdated {
+    /// All bodies created by this operation.
+    pub bodies: Vec<BodyUpdated>,
+}
+
+impl BodiesUpdated {
+    /// Are there any bodies in this list?
+    pub fn is_empty(&self) -> bool {
+        self.bodies.is_empty()
+    }
 }
 
 /// Details of a body that was created.
@@ -1931,6 +1956,19 @@ pub struct BodyCreated {
     /// The body's ID.
     pub id: Uuid,
     /// Surfaces this body contains.
+    pub surfaces: Vec<SurfaceCreated>,
+}
+
+/// Details of a body that was updated.
+#[derive(Builder, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+pub struct BodyUpdated {
+    /// The body's ID.
+    pub id: Uuid,
+    /// Surfaces added to this body.
     pub surfaces: Vec<SurfaceCreated>,
 }
 

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -1852,25 +1852,35 @@ pub struct SurfaceCreated {
 
 impl From<BodyCreated> for BodyUpdated {
     fn from(body: BodyCreated) -> Self {
-        Self { id: body.id, surfaces: body.surfaces }
+        Self {
+            id: body.id,
+            surfaces: body.surfaces,
+        }
     }
 }
 
 impl From<BodyUpdated> for BodyCreated {
     fn from(body: BodyUpdated) -> Self {
-        Self { id: body.id, surfaces: body.surfaces }
+        Self {
+            id: body.id,
+            surfaces: body.surfaces,
+        }
     }
 }
 
 impl From<BodiesCreated> for BodiesUpdated {
     fn from(bodies: BodiesCreated) -> Self {
-        Self { bodies: bodies.bodies.into_iter().map(Into::into).collect() }
+        Self {
+            bodies: bodies.bodies.into_iter().map(Into::into).collect(),
+        }
     }
 }
 
 impl From<BodiesUpdated> for BodiesCreated {
     fn from(bodies: BodiesUpdated) -> Self {
-        Self { bodies: bodies.bodies.into_iter().map(Into::into).collect() }
+        Self {
+            bodies: bodies.bodies.into_iter().map(Into::into).collect(),
+        }
     }
 }
 

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -1850,6 +1850,18 @@ pub struct SurfaceCreated {
     pub from_segments: Vec<Uuid>,
 }
 
+impl From<BodyCreated> for BodyUpdated {
+    fn from(body: BodyCreated) -> Self {
+        Self { id: body.id, surfaces: body.surfaces }
+    }
+}
+
+impl From<BodyUpdated> for BodyCreated {
+    fn from(body: BodyUpdated) -> Self {
+        Self { id: body.id, surfaces: body.surfaces }
+    }
+}
+
 fn one() -> f32 {
     1.0
 }

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -1910,6 +1910,45 @@ pub struct SurfaceEdgeReference {
     pub edges: Vec<FractionOfEdge>,
 }
 
+/// List of bodies that were created by an operation.
+#[derive(Builder, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+pub struct BodiesCreated {
+    /// All bodies created by this operation.
+    pub bodies: Vec<BodyCreated>,
+}
+
+/// Details of a body that was created.
+#[derive(Builder, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+pub struct BodyCreated {
+    /// The body's ID.
+    pub id: Uuid,
+    /// Surfaces this body contains.
+    pub surfaces: Vec<SurfaceCreated>,
+}
+
+/// Details of a surface that was created under some body.
+#[derive(Builder, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+pub struct SurfaceCreated {
+    /// The surface's ID.
+    pub id: Uuid,
+    /// Which number face of the parent body is this?
+    pub primitive_face_index: u32,
+    /// Which segment IDs was this surface swept from?
+    pub from_segments: Vec<Uuid>,
+}
+
 fn one() -> f32 {
     1.0
 }


### PR DESCRIPTION
This proposes a new way to surface extrude/revolve/sweep for sketch 2. Part of https://github.com/KittyCAD/modeling-app/issues/10386

## Background

Currently, the engine extrude/revolve/sweep/etc endpoints take an _entire sketch_ as their target. That worked fine for sketch 1 solid extrudes (where the sketch is a closed profile) and for surface extrudes (where the sketch could be closed or open, either way, it extrudes each segment separately).

## Problem

In sketch 2, the user might want to surface extrude only some segments in the sketch. Like in the below example, only _k_ of the _n_ segments are selected for extrusion.

<img width="342" height="335" alt="Screenshot 2026-03-12 at 10 32 39 AM" src="https://github.com/user-attachments/assets/b595a2c9-1a7d-4321-acc7-cb1c06c20ae0" />

Right now the API doesn't allow for this. Clients send the ID of the overall sketch, and the server extrudes the whole thing. There's no way to only surface extrude _k_ of the _n_ segments.

## Solution

Instead of extruding an entire sketch (solid2D) at once, we instead take a list of segments and extrude each of those separately.

Here's a motivating example:

<img width="1418" height="590" alt="new_extrude_system" src="https://github.com/user-attachments/assets/a382e804-2d58-4ab1-9607-a9b4f34a902e" />

In this example, after extruding:

- C becomes a single-surface body
- D and E become a polysurface (D is extruded into one surface, E into another)
- A and B become a single-body surface by default (because they're collinear) unless the user opts out by setting a keepSeams flag in KCL.

We want to:
- Keep the old path segments A-E existing, unchanged (same IDs).
- Create new bodies (Solid3Ds) from them.
  - Frontend cannot predict the number of bodies in advance (because frontend doesn't know which segments intersect, or are collinear).
  - So engine will need to tell the frontend how many bodies were created, and what their IDs are.
- Get a mapping between segments and surfaces, so that tags can transfer.
  - e.g. frontend must know that:
  - segment A and B were absorbed into body 1 face 0
  - segment C became body 2 face 0
  - segment D became body 0 face 0
  - segment E became body 0 face 1

Ideally we would not need any follow-up calls to query these bodies. Let's just send back all relevant information in the Extrude response.


Here's my proposed return for Extrude. I'm using YAML because it's more concise, but we'd actually be sending JSON. See the attachment for syntax highlighting, or copypastable here:
```yaml
bodies:
  - id: body0
    surfaces:
      - faceIndex: 0
        faceId: <uuid>
        fromSegments: [d0000000-0000-0000-0000-000000000000]
      - faceIndex: 1
        faceId: <uuid>
        fromSegments: [e0000000-0000-0000-0000-000000000000]
  - id: body1
    surfaces:
      - faceIndex: 0
        faceId: <uuid>
        fromSegments: [a0000000-0000-0000-0000-000000000000, b0000000-0000-0000-0000-000000000000]
  - id: body2
    surfaces:
      - faceIndex: 0
        faceId: <uuid>
        fromSegments: [c0000000-0000-0000-0000-000000000000]
```