### PR TITLE
Cubic millimeter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,6 +2383,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kittycad-measurements"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7412b22b064c31f34dcc35097a1c2d16dd73c4d2f7bf1b059d39eed9accfc332"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "kittycad-modeling-cmds"
 version = "0.2.195"
 dependencies = [
@@ -2399,9 +2408,9 @@ dependencies = [
  "euler",
  "expectorate",
  "http",
+ "kittycad-measurements",
  "kittycad-modeling-cmds-macros",
  "kittycad-unit-conversion-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "measurements",
  "openapi-lint",
  "openapiv3",
  "parse-display",
@@ -2651,15 +2660,6 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest",
-]
-
-[[package]]
-name = "measurements"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f72b38901c571007811f0483e64a7e215ac9e6e3688e9f83705a717621d81513"
-dependencies = [
- "libm",
 ]
 
 [[package]]

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -37,7 +37,8 @@ euler = "0.4.1"
 http = "1.4.0"
 kittycad-modeling-cmds-macros = { workspace = true }
 kittycad-unit-conversion-derive = "0.1.0"
-measurements = "0.11.0"
+# Fork of <crates.io/crates/measurements>
+measurements = { package = "kittycad-measurements", version = "0.11.2" }
 parse-display = "0.10.0"
 parse-display-derive = "0.10.0"
 pyo3 = { version = "0.25.1", optional = true }

--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -9173,6 +9173,13 @@
         "description": "The valid types of volume units.",
         "oneOf": [
           {
+            "description": "Cubic millimeters (mm³)",
+            "type": "string",
+            "enum": [
+              "mm3"
+            ]
+          },
+          {
             "description": "Cubic centimeters (cc or cm³) <https://en.wikipedia.org/wiki/Cubic_centimeter>",
             "type": "string",
             "enum": [

--- a/modeling-cmds/src/units.rs
+++ b/modeling-cmds/src/units.rs
@@ -325,6 +325,10 @@ impl UnitMass {
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
 #[cfg_attr(feature = "python", pyo3::pyclass(eq), pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
 pub enum UnitVolume {
+    /// Cubic millimeters (mm³)
+    #[serde(rename = "mm3")]
+    #[display("mm3")]
+    CubicMillimeters,
     /// Cubic centimeters (cc or cm³) <https://en.wikipedia.org/wiki/Cubic_centimeter>
     #[serde(rename = "cm3")]
     #[display("cm3")]
@@ -368,6 +372,7 @@ impl UnitVolume {
     /// Convert to measurement.
     pub fn as_measurement(self, value: f64) -> measurements::Volume {
         match self {
+            Self::CubicMillimeters => measurements::Volume::from_cubic_millimeters(value),
             Self::CubicCentimeters => measurements::Volume::from_cubic_centimeters(value),
             Self::CubicFeet => measurements::Volume::from_cubic_feet(value),
             Self::CubicInches => measurements::Volume::from_cubic_inches(value),


### PR DESCRIPTION
Part of https://github.com/KittyCAD/modeling-app/issues/11474

Relies on https://github.com/rust-embedded-community/rust-measurements/pull/68

As far as I can tell, this should Just Work once we update the engine. It doesn't cause any compile errors anywhere, the various services (frontend, CLI, engine etc) just need to update and pull this in so they understand what a cubic millimeter is, if something requests it.