### PR TITLE
Bump pyo3 to 0.28.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,15 +2186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inflections"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,15 +2705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2854,7 +2836,7 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
- "memoffset 0.7.1",
+ "memoffset",
  "pin-utils",
 ]
 
@@ -2968,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.26.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2dba356160b54f5371b550575b78130a54718b4c6e46b3f33a6da74a27e78b"
+checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
 dependencies = [
  "libc",
  "ndarray",
@@ -3534,35 +3516,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "indoc",
  "libc",
- "memoffset 0.9.1",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3570,9 +3549,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3582,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5711,12 +5690,6 @@ dependencies = [
  "phf_codegen",
  "rand 0.8.5",
 ]
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -42,7 +42,11 @@ measurements = { package = "kittycad-measurements", version = "0.11.2" }
 parse-display = "0.10.0"
 parse-display-derive = "0.10.0"
 pyo3 = { version = "0.28.3", optional = true }
-pyo3-stub-gen = { version = "0.22.3", optional = true }
+pyo3-stub-gen = { version = "0.22.3", optional = true, default-features = false, features = [
+  "either",
+  "numpy",
+  "ordered-float",
+] }
 schemars = { version = "0.8.22", features = ["bigdecimal04", "chrono", "url", "uuid1"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_bytes = "0.11.19"

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -41,7 +41,7 @@ kittycad-unit-conversion-derive = "0.1.0"
 measurements = { package = "kittycad-measurements", version = "0.11.2" }
 parse-display = "0.10.0"
 parse-display-derive = "0.10.0"
-pyo3 = { version = "0.26.0", optional = true }
+pyo3 = { version = "0.28.3", optional = true }
 pyo3-stub-gen = { version = "0.22.3", optional = true }
 schemars = { version = "0.8.22", features = ["bigdecimal04", "chrono", "url", "uuid1"] }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/modeling-cmds/src/base64.rs
+++ b/modeling-cmds/src/base64.rs
@@ -18,7 +18,11 @@ static ALLOWED_DECODING_FORMATS: &[data_encoding::Encoding] = &[
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "python", pyo3::pyclass, pyo3_stub_gen::derive::gen_stub_pyclass)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass
+)]
 /// A container for binary that should be base64 encoded in serialisation. In reverse
 /// when deserializing, will decode from many different types of base64 possible.
 pub struct Base64Data(pub Vec<u8>);

--- a/modeling-cmds/src/coord.rs
+++ b/modeling-cmds/src/coord.rs
@@ -13,7 +13,11 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(feature = "python", pyo3::pyclass, pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass_enum
+)]
 pub enum Axis {
     /// 'Y' axis.
     Y = 1,
@@ -28,7 +32,11 @@ pub enum Axis {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(feature = "python", pyo3::pyclass, pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass_enum
+)]
 pub enum Direction {
     /// Increasing numbers.
     Positive = 1,
@@ -53,7 +61,11 @@ impl std::ops::Mul for Direction {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(feature = "python", pyo3::pyclass, pyo3_stub_gen::derive::gen_stub_pyclass)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass
+)]
 pub struct AxisDirectionPair {
     /// Axis specifier.
     pub axis: Axis,
@@ -74,7 +86,11 @@ pub struct AxisDirectionPair {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(feature = "python", pyo3::pyclass, pyo3_stub_gen::derive::gen_stub_pyclass)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass
+)]
 pub struct System {
     /// Axis the front face of a model looks along.
     pub forward: AxisDirectionPair,

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -1794,7 +1794,7 @@ define_modeling_cmd_enum! {
         #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
         #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
         #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-        #[cfg_attr(feature = "python", pyo3::pyclass, pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
+        #[cfg_attr(feature = "python", pyo3::pyclass(from_py_object), pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub enum ImageFormat {
             /// .png format

--- a/modeling-cmds/src/format/dxf.rs
+++ b/modeling-cmds/src/format/dxf.rs
@@ -13,7 +13,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass_enum,
-        pyo3::pyclass(name = "DxfStorage")
+        pyo3::pyclass(name = "DxfStorage", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub enum Storage {
@@ -36,7 +36,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "DxfExportOptions")
+        pyo3::pyclass(name = "DxfExportOptions", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub struct Options {

--- a/modeling-cmds/src/format/fbx.rs
+++ b/modeling-cmds/src/format/fbx.rs
@@ -15,7 +15,7 @@ pub mod import {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "FbxImportOptions")
+        pyo3::pyclass(name = "FbxImportOptions", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub struct Options {}
@@ -44,7 +44,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "FbxExportOptions")
+        pyo3::pyclass(name = "FbxExportOptions", from_py_object)
     )]
     #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
@@ -79,7 +79,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass_enum,
-        pyo3::pyclass(name = "FbxStorage")
+        pyo3::pyclass(name = "FbxStorage", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub enum Storage {

--- a/modeling-cmds/src/format/gltf.rs
+++ b/modeling-cmds/src/format/gltf.rs
@@ -16,7 +16,7 @@ pub mod import {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "GltfImportOptions")
+        pyo3::pyclass(name = "GltfImportOptions", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub struct Options {}
@@ -44,7 +44,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "GltfExportOptions")
+        pyo3::pyclass(name = "GltfExportOptions", from_py_object)
     )]
     #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
@@ -80,7 +80,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass_enum,
-        pyo3::pyclass(name = "GltfStorage")
+        pyo3::pyclass(name = "GltfStorage", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub enum Storage {

--- a/modeling-cmds/src/format/mod.rs
+++ b/modeling-cmds/src/format/mod.rs
@@ -72,7 +72,7 @@ pub type InputFormat = InputFormat3d;
 #[serde(tag = "type", rename_all = "snake_case")]
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass,
+    pyo3::pyclass(from_py_object),
     pyo3_stub_gen::derive::gen_stub_pyclass_complex_enum
 )]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
@@ -395,7 +395,7 @@ macro_rules! proprietary_brep_formats {
                     #[cfg_attr(
                         feature = "python",
                         pyo3_stub_gen::derive::gen_stub_pyclass,
-                        pyo3::pyclass(name = $spec_name)
+                        pyo3::pyclass(name = $spec_name, from_py_object)
                     )]
                     pub struct Options {
                         /// Co-ordinate system of input data.

--- a/modeling-cmds/src/format/obj.rs
+++ b/modeling-cmds/src/format/obj.rs
@@ -17,7 +17,7 @@ pub mod import {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "ObjImportOptions")
+        pyo3::pyclass(name = "ObjImportOptions", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub struct Options {
@@ -72,7 +72,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "ObjExportOptions")
+        pyo3::pyclass(name = "ObjExportOptions", from_py_object)
     )]
     #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]

--- a/modeling-cmds/src/format/ply.rs
+++ b/modeling-cmds/src/format/ply.rs
@@ -18,7 +18,7 @@ pub mod import {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "PlyImportOptions")
+        pyo3::pyclass(name = "PlyImportOptions", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub struct Options {
@@ -74,7 +74,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "PlyExportOptions")
+        pyo3::pyclass(name = "PlyExportOptions", from_py_object)
     )]
     #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
@@ -134,7 +134,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass_enum,
-        pyo3::pyclass(name = "PlyStorage")
+        pyo3::pyclass(name = "PlyStorage", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub enum Storage {

--- a/modeling-cmds/src/format/step.rs
+++ b/modeling-cmds/src/format/step.rs
@@ -18,7 +18,7 @@ pub mod import {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "StepImportOptions")
+        pyo3::pyclass(name = "StepImportOptions", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub struct Options {
@@ -75,7 +75,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass_enum,
-        pyo3::pyclass(name = "StepPresentation")
+        pyo3::pyclass(name = "StepPresentation", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub enum Presentation {
@@ -97,7 +97,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "StepExportOptions")
+        pyo3::pyclass(name = "StepExportOptions", from_py_object)
     )]
     #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]

--- a/modeling-cmds/src/format/stl.rs
+++ b/modeling-cmds/src/format/stl.rs
@@ -18,7 +18,7 @@ pub mod import {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "StlImportOptions")
+        pyo3::pyclass(name = "StlImportOptions", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub struct Options {
@@ -73,7 +73,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass,
-        pyo3::pyclass(name = "StlExportOptions")
+        pyo3::pyclass(name = "StlExportOptions", from_py_object)
     )]
     #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
@@ -135,7 +135,7 @@ pub mod export {
     #[cfg_attr(
         feature = "python",
         pyo3_stub_gen::derive::gen_stub_pyclass_enum,
-        pyo3::pyclass(name = "StlStorage")
+        pyo3::pyclass(name = "StlStorage", from_py_object)
     )]
     #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
     pub enum Storage {

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -1165,7 +1165,11 @@ pub enum CurveType {
 
 /// A file to be exported to the client.
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq, Builder)]
-#[cfg_attr(feature = "python", pyo3::pyclass, pyo3_stub_gen::derive::gen_stub_pyclass)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass
+)]
 #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
 pub struct ExportFile {
     /// The name of the file.
@@ -1198,7 +1202,11 @@ impl ExportFile {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(feature = "python", pyo3::pyclass, pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass_enum
+)]
 #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
 pub enum FileExportFormat {
     /// Autodesk Filmbox (FBX) format. <https://en.wikipedia.org/wiki/FBX>

--- a/modeling-cmds/src/units.rs
+++ b/modeling-cmds/src/units.rs
@@ -29,7 +29,11 @@ use crate::impl_extern_type;
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(feature = "python", pyo3::pyclass(eq), pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(eq, from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass_enum
+)]
 pub enum UnitLength {
     /// Centimeters <https://en.wikipedia.org/wiki/Centimeter>
     #[serde(rename = "cm")]
@@ -102,7 +106,11 @@ impl_extern_type! {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(feature = "python", pyo3::pyclass(eq), pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(eq, from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass_enum
+)]
 pub enum UnitAngle {
     /// Degrees <https://en.wikipedia.org/wiki/Degree_(angle)>
     #[default]
@@ -137,7 +145,11 @@ pub enum UnitAngle {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(feature = "python", pyo3::pyclass(eq), pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(eq, from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass_enum
+)]
 pub enum UnitArea {
     /// Square centimeters <https://en.wikipedia.org/wiki/Square_centimeter>
     #[serde(rename = "cm2")]
@@ -212,7 +224,11 @@ impl UnitArea {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(feature = "python", pyo3::pyclass(eq), pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(eq, from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass_enum
+)]
 pub enum UnitDensity {
     /// Pounds per cubic feet.
     #[serde(rename = "lb:ft3")]
@@ -272,7 +288,11 @@ impl UnitDensity {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(feature = "python", pyo3::pyclass(eq), pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(eq, from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass_enum
+)]
 pub enum UnitMass {
     /// Grams <https://en.wikipedia.org/wiki/Gram>
     #[default]
@@ -323,7 +343,11 @@ impl UnitMass {
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(feature = "python", pyo3::pyclass(eq), pyo3_stub_gen::derive::gen_stub_pyclass_enum)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(eq, from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass_enum
+)]
 pub enum UnitVolume {
     /// Cubic millimeters (mm³)
     #[serde(rename = "mm3")]

--- a/modeling-cmds/src/websocket.rs
+++ b/modeling-cmds/src/websocket.rs
@@ -327,7 +327,11 @@ impl WebSocketResponse {
 /// A raw file with unencoded contents to be passed over binary websockets.
 /// When raw files come back for exports it is sent as binary/bson, not text/json.
 #[derive(Debug, Serialize, Deserialize, JsonSchema, Clone, PartialEq)]
-#[cfg_attr(feature = "python", pyo3::pyclass, pyo3_stub_gen::derive::gen_stub_pyclass)]
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(from_py_object),
+    pyo3_stub_gen::derive::gen_stub_pyclass
+)]
 pub struct RawFile {
     /// The name of the file.
     pub name: String,


### PR DESCRIPTION
Enables us to bump pyo3 in the modeling-app repo (for KCL python bindings), see https://github.com/KittyCAD/modeling-app/pull/11838