### PR TITLE
Release modeling-cmds 0.2.203

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,7 +2414,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.202"
+version = "0.2.203"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.202"
+version = "0.2.203"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Changed

 - Some structs are now marked non-exhaustive and have a Builder API (#1221)