### PR TITLE
New command, 'ExecKclProject'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2375,7 +2375,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2435,6 +2435,16 @@ checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kcl-api"
+version = "0.2.164"
+source = "git+https://github.com/KittyCAD/modeling-app?branch=achalmers/kcl-in-engine#9672dc7ee9dacd30b7fda17bab15d971b4488da3"
+dependencies = [
+ "schemars",
+ "serde",
+ "ts-rs",
 ]
 
 [[package]]
@@ -2503,6 +2513,7 @@ dependencies = [
  "euler",
  "expectorate",
  "http",
+ "kcl-api",
  "kittycad-measurements",
  "kittycad-modeling-cmds-macros",
  "kittycad-unit-conversion-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4323,7 +4334,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4916,7 +4927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5147,7 +5158,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5156,7 +5167,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6297,7 +6308,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
  "getrandom 0.2.16",
  "getrandom 0.3.4",
  "hex",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "js-sys",
  "once_cell",
  "rand 0.9.2",
@@ -758,7 +758,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -836,7 +836,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -1081,7 +1081,7 @@ checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
 dependencies = [
  "cc",
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "scratch",
@@ -1096,7 +1096,7 @@ checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
 dependencies = [
  "clap",
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1114,7 +1114,7 @@ version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1263,7 +1263,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "multer",
  "openapiv3",
  "paste",
@@ -1432,7 +1432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1721,7 +1721,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1813,7 +1813,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1848,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2249,12 +2249,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2375,7 +2375,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2440,10 +2440,24 @@ dependencies = [
 [[package]]
 name = "kcl-api"
 version = "0.2.164"
-source = "git+https://github.com/KittyCAD/modeling-app?branch=achalmers/kcl-in-engine#9672dc7ee9dacd30b7fda17bab15d971b4488da3"
 dependencies = [
+ "indexmap 2.14.0",
+ "kcl-error",
  "schemars",
  "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ts-rs",
+]
+
+[[package]]
+name = "kcl-error"
+version = "0.2.164"
+dependencies = [
+ "miette",
+ "schemars",
+ "serde",
+ "serde_json",
  "ts-rs",
 ]
 
@@ -2796,6 +2810,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3109,7 +3145,7 @@ version = "0.4.0"
 source = "git+https://github.com/KittyCAD/openapi-lint?branch=kittycad#7c5cf3957e58b2a4d57c82557552115c49183bd3"
 dependencies = [
  "heck 0.4.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "lazy_static",
  "openapiv3",
  "regex",
@@ -3121,7 +3157,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
 ]
@@ -3226,7 +3262,7 @@ checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
 dependencies = [
  "bytecount",
  "fnv",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -3697,7 +3733,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "either",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "inventory",
  "itertools 0.14.0",
  "log",
@@ -3721,7 +3757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd9a73abe6f57890e657c265b86805637138f83203e1a56bc156078abf215e36"
 dependencies = [
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "rustpython-parser",
@@ -4334,7 +4370,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4671,7 +4707,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -4927,7 +4963,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5158,7 +5194,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5167,7 +5203,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5185,7 +5221,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5430,7 +5466,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -5463,7 +5499,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -5477,7 +5513,7 @@ version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -5629,9 +5665,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756050066659291d47a554a9f558125db17428b073c5ffce1daf5dcb0f7231d8"
 dependencies = [
  "chrono",
+ "indexmap 2.14.0",
  "serde_json",
  "thiserror 2.0.18",
  "ts-rs-macros",
+ "url",
  "uuid",
 ]
 
@@ -5760,6 +5798,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -6010,7 +6054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6038,7 +6082,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.10.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -6308,7 +6352,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6628,7 +6672,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -6659,7 +6703,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -6678,7 +6722,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -18,7 +18,7 @@ tabled = ["dep:tabled"]
 ts-rs = ["dep:ts-rs"]
 slog = ["dep:slog"]
 cxx = ["dep:cxx"]
-websocket = ["dep:serde_json"]
+websocket = []
 webrtc = ["dep:webrtc"]
 unstable_exhaustive = []
 python = ["dep:pyo3", "dep:pyo3-stub-gen"]
@@ -36,6 +36,7 @@ enum-iterator-derive = "1.2.1"
 euler = "0.4.1"
 http = "1.4.0"
 kittycad-modeling-cmds-macros = { workspace = true }
+kcl-api = { version = "0.2.164", git = "https://github.com/KittyCAD/modeling-app", branch = "achalmers/kcl-in-engine" }
 kittycad-unit-conversion-derive = "0.1.0"
 # Fork of <crates.io/crates/measurements>
 measurements = { package = "kittycad-measurements", version = "0.11.2" }
@@ -50,7 +51,7 @@ pyo3-stub-gen = { version = "0.22.3", optional = true, default-features = false,
 schemars = { version = "0.8.22", features = ["bigdecimal04", "chrono", "url", "uuid1"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_bytes = "0.11.19"
-serde_json = { version = "1.0.150", optional = true }
+serde_json = "1.0.150"
 slog = { version = "2.8.2", optional = true }
 tabled = { version = "0.20", optional = true }
 ts-rs = { version = "12.0.1", optional = true, features = ["chrono-impl", "uuid-impl", "no-serde-warnings", "serde-json-impl"] }

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -36,7 +36,7 @@ enum-iterator-derive = "1.2.1"
 euler = "0.4.1"
 http = "1.4.0"
 kittycad-modeling-cmds-macros = { workspace = true }
-kcl-api = { version = "0.2.164", git = "https://github.com/KittyCAD/modeling-app", branch = "achalmers/kcl-in-engine" }
+kcl-api = { version = "0.2.164", path = "../../modeling-app/rust/kcl-api" }
 kittycad-unit-conversion-derive = "0.1.0"
 # Fork of <crates.io/crates/measurements>
 measurements = { package = "kittycad-measurements", version = "0.11.2" }

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -23,12 +23,12 @@ define_modeling_cmd_enum! {
             format::{OutputFormat2d, OutputFormat3d},
             id::ModelingCmdId,
             length_unit::LengthUnit,
+            exec_kcl::KclProject,
             shared::{
                 Angle,
                 RegionVersion,
                 BlendType,
                 BodyType,
-                KclProject,
                 EdgeCutVersion,
                 ComponentTransform,
                 RelativeTo,

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -28,6 +28,7 @@ define_modeling_cmd_enum! {
                 RegionVersion,
                 BlendType,
                 BodyType,
+                KclProject,
                 EdgeCutVersion,
                 ComponentTransform,
                 RelativeTo,
@@ -2725,6 +2726,17 @@ define_modeling_cmd_enum! {
             /// Find the edge closest to this point.
             /// Assumed to be in absolute coordinates, relative to global (scene) origin.
             pub closest_to: Point3d<f64>,
+        }
+
+        /// Execute this KCL project.
+        #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, ModelingCmdVariant, Builder)]
+        #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+        #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+        #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+        #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+        pub struct ExecKclProject {
+            /// The KCL project to execute.
+            pub project: KclProject,
         }
     }
 

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -23,7 +23,6 @@ define_modeling_cmd_enum! {
             format::{OutputFormat2d, OutputFormat3d},
             id::ModelingCmdId,
             length_unit::LengthUnit,
-            exec_kcl::KclProject,
             shared::{
                 Angle,
                 RegionVersion,
@@ -2727,20 +2726,7 @@ define_modeling_cmd_enum! {
             /// Assumed to be in absolute coordinates, relative to global (scene) origin.
             pub closest_to: Point3d<f64>,
         }
-
-        /// Execute this KCL project.
-        #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, ModelingCmdVariant, Builder)]
-        #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-        #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-        #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-        #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
-        pub struct ExecKclProject {
-            /// The KCL project to execute.
-            pub project: KclProject,
-        }
     }
-
-
 }
 
 pub(crate) fn is_false(b: &bool) -> bool {

--- a/modeling-cmds/src/exec_kcl.rs
+++ b/modeling-cmds/src/exec_kcl.rs
@@ -52,7 +52,20 @@ pub struct ExecKclProjectOk {
 /// Failed KCL project execution response.
 pub struct ExecKclProjectErr {
     /// Error produced while executing the KCL project.
-    pub error: kcl_api::Error,
+    pub error: kcl_api::KclErrorWithOutputs<
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+        kcl_api::SceneGraph<serde_json::Value, serde_json::Value>,
+        serde_json::Value,
+        serde_json::Value,
+        serde_json::Value,
+    >,
 }
 
 #[cfg(feature = "arbitrary")]
@@ -75,9 +88,9 @@ impl<'a> arbitrary::Arbitrary<'a> for ExecKclProjectOk {
 impl<'a> arbitrary::Arbitrary<'a> for ExecKclProjectErr {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
-            error: kcl_api::Error {
-                msg: <String as arbitrary::Arbitrary>::arbitrary(u)?,
-            },
+            error: kcl_api::KclErrorWithOutputs::no_outputs(kcl_api::KclError::internal(
+                <String as arbitrary::Arbitrary>::arbitrary(u)?,
+            )),
         })
     }
 }

--- a/modeling-cmds/src/exec_kcl.rs
+++ b/modeling-cmds/src/exec_kcl.rs
@@ -1,18 +1,83 @@
 use bon::Builder;
 use schemars::JsonSchema;
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
+use crate::shared::safe_filepath::SafeFilepath;
+
+/// A KCL project that can be executed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default, Builder)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
 #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
-pub struct ExecKclProjectOk {}
+pub struct KclProject {
+    /// All files in the project.
+    pub files: Vec<KclFile>,
+    /// Which file is the entrypoint?
+    /// This is the first KCL file to be executed,
+    /// the root of the KCL module tree.
+    pub entrypoint: SafeFilepath,
+}
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
+/// Region-creation algorithm version.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default, Builder)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
 #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
-pub struct ExecKclProjectErr {}
+pub struct KclFile {
+    /// Where is the file, relative to the project directory?
+    pub path: SafeFilepath,
+    /// Contents of the file, as UTF-8 encoded bytes.
+    #[serde(deserialize_with = "serde_bytes::deserialize")]
+    #[serde(serialize_with = "serde_bytes::serialize")]
+    pub contents: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+/// Successful KCL project execution response.
+pub struct ExecKclProjectOk {
+    /// Scene graph updates and execution metadata produced by running the KCL project.
+    pub scene_graph_delta:
+        kcl_api::SceneGraphDelta<kcl_api::SceneGraph<serde_json::Value, serde_json::Value>, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+/// Failed KCL project execution response.
+pub struct ExecKclProjectErr {
+    /// Error produced while executing the KCL project.
+    pub error: kcl_api::Error,
+}
+
+#[cfg(feature = "arbitrary")]
+// TODO: Impl this properly for fuzzing.
+impl<'a> arbitrary::Arbitrary<'a> for ExecKclProjectOk {
+    fn arbitrary(_u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            scene_graph_delta: kcl_api::SceneGraphDelta::new(
+                kcl_api::SceneGraph::empty(kcl_api::ProjectId(0), kcl_api::FileId(0), kcl_api::Version(0)),
+                Vec::new(),
+                false,
+                serde_json::Value::Null,
+            ),
+        })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+// TODO: Impl this properly for fuzzing.
+impl<'a> arbitrary::Arbitrary<'a> for ExecKclProjectErr {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            error: kcl_api::Error {
+                msg: <String as arbitrary::Arbitrary>::arbitrary(u)?,
+            },
+        })
+    }
+}

--- a/modeling-cmds/src/exec_kcl.rs
+++ b/modeling-cmds/src/exec_kcl.rs
@@ -1,0 +1,18 @@
+use bon::Builder;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+pub struct ExecKclProjectOk {}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+pub struct ExecKclProjectErr {}

--- a/modeling-cmds/src/lib.rs
+++ b/modeling-cmds/src/lib.rs
@@ -35,6 +35,9 @@ pub mod session;
 /// Types that are shared between various modeling commands, like Point3d.
 pub mod shared;
 
+/// Types for executing KCL and getting response back.
+pub mod exec_kcl;
+
 #[cfg(all(test, feature = "derive-jsonschema-on-enums"))]
 mod tests;
 

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -1387,5 +1387,13 @@ define_ok_modeling_cmd_response_enum! {
             /// If there are no edges in the scene, returns None.
             pub edge_id: Option<Uuid>,
         }
+
+        /// The response from the 'ExecKclProject'.
+        #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema, ModelingCmdOutput)]
+        #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+        pub struct ExecKclProject {
+            /// Result after executing KCL.
+            pub result: Result<crate::exec_kcl::ExecKclProjectOk, crate::exec_kcl::ExecKclProjectErr>,
+        }
     }
 }

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -1387,13 +1387,5 @@ define_ok_modeling_cmd_response_enum! {
             /// If there are no edges in the scene, returns None.
             pub edge_id: Option<Uuid>,
         }
-
-        /// The response from the 'ExecKclProject'.
-        #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema, ModelingCmdOutput)]
-        #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
-        pub struct ExecKclProject {
-            /// Result after executing KCL.
-            pub result: Result<crate::exec_kcl::ExecKclProjectOk, crate::exec_kcl::ExecKclProjectErr>,
-        }
     }
 }

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -8,9 +8,16 @@ use uuid::Uuid;
 
 #[cfg(feature = "cxx")]
 use crate::impl_extern_type;
-use crate::{def_enum::negative_one, length_unit::LengthUnit, output::ExtrusionFaceInfo, units, units::UnitAngle};
+use crate::{
+    def_enum::negative_one,
+    length_unit::LengthUnit,
+    output::ExtrusionFaceInfo,
+    shared::safe_filepath::SafeFilepath,
+    units::{self, UnitAngle},
+};
 
 mod point;
+mod safe_filepath;
 
 /// An edge can be referenced by its uuid or by the faces that uniquely define it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
@@ -2176,4 +2183,30 @@ impl From<BodiesUpdated> for BodiesCreated {
 
 fn one() -> f32 {
     1.0
+}
+
+/// A KCL project that can be executed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default, Builder)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+pub struct KclProject {
+    /// All files in the project.
+    files: Vec<KclFile>,
+}
+
+/// Region-creation algorithm version.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default, Builder)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+pub struct KclFile {
+    /// Where is the file, relative to the project directory?
+    pub path: SafeFilepath,
+    /// Contents of the file, as UTF-8 encoded bytes.
+    #[serde(deserialize_with = "serde_bytes::deserialize")]
+    #[serde(serialize_with = "serde_bytes::serialize")]
+    pub contents: Vec<u8>,
 }

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -12,12 +12,11 @@ use crate::{
     def_enum::negative_one,
     length_unit::LengthUnit,
     output::ExtrusionFaceInfo,
-    shared::safe_filepath::SafeFilepath,
     units::{self, UnitAngle},
 };
 
 mod point;
-mod safe_filepath;
+pub mod safe_filepath;
 
 /// An edge can be referenced by its uuid or by the faces that uniquely define it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
@@ -2183,30 +2182,4 @@ impl From<BodiesUpdated> for BodiesCreated {
 
 fn one() -> f32 {
     1.0
-}
-
-/// A KCL project that can be executed.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default, Builder)]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
-pub struct KclProject {
-    /// All files in the project.
-    files: Vec<KclFile>,
-}
-
-/// Region-creation algorithm version.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default, Builder)]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
-pub struct KclFile {
-    /// Where is the file, relative to the project directory?
-    pub path: SafeFilepath,
-    /// Contents of the file, as UTF-8 encoded bytes.
-    #[serde(deserialize_with = "serde_bytes::deserialize")]
-    #[serde(serialize_with = "serde_bytes::serialize")]
-    pub contents: Vec<u8>,
 }

--- a/modeling-cmds/src/shared/safe_filepath.rs
+++ b/modeling-cmds/src/shared/safe_filepath.rs
@@ -1,0 +1,61 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::path::{Component, PathBuf};
+
+/// Filepath which is guaranteed to be relative and not contain parent directory jumps like '..'
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(transparent)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+pub struct SafeFilepath(PathBuf);
+
+impl From<SafeFilepath> for PathBuf {
+    fn from(value: SafeFilepath) -> Self {
+        value.0
+    }
+}
+
+/// Validation error that can occur when trying to send a file to the Zoo API.
+#[derive(Debug)]
+pub enum PathNotSafe {
+    /// Cannot use an absolute path.
+    CannotBeAbsolute,
+    /// Cannot use a parent path component (..)
+    CannotUseParent,
+}
+
+impl std::fmt::Display for PathNotSafe {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Paths must be relative and cannot contain parent jumps like '..' inside"
+        )
+    }
+}
+
+impl SafeFilepath {
+    /// Validate if a path meets the invariants of this type,
+    /// i.e. is relative and doesn't contain any parent components (..)
+    pub fn validate(unparsed_user_path: &str) -> Result<Self, PathNotSafe> {
+        let user_path = std::path::Path::new(unparsed_user_path);
+
+        // Cannot be absolute.
+        if user_path.is_absolute() {
+            return Err(PathNotSafe::CannotBeAbsolute);
+        }
+
+        // Check all components to make sure there's no absolute or escaping from the project root.
+        for component in user_path.components() {
+            match component {
+                Component::RootDir | Component::Prefix(..) => return Err(PathNotSafe::CannotBeAbsolute),
+                Component::ParentDir => return Err(PathNotSafe::CannotUseParent),
+                Component::CurDir | Component::Normal(..) => {}
+            }
+        }
+
+        // All checks passed, so it's OK.
+        Ok(Self(user_path.to_owned()))
+    }
+}

--- a/modeling-cmds/src/shared/safe_filepath.rs
+++ b/modeling-cmds/src/shared/safe_filepath.rs
@@ -1,3 +1,4 @@
+//! Filepaths safe to use in KCL projects because they cannot escape the KCL project root.
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::{Component, PathBuf};
@@ -57,5 +58,48 @@ impl SafeFilepath {
 
         // All checks passed, so it's OK.
         Ok(Self(user_path.to_owned()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::assert_matches;
+
+    #[test]
+    fn test_absolute_not_allowed_unix() {
+        // Absolute paths could allow reading from arbitrary files
+        let input = "/foo/bar";
+        let actual = SafeFilepath::validate(input);
+        assert_matches!(actual, Err(PathNotSafe::CannotBeAbsolute));
+    }
+
+    #[test]
+    fn test_absolute_not_allowed_windows() {
+        // Test windows-style absolute paths.
+        let input = r"C:\programs\bar";
+        let actual = SafeFilepath::validate(input);
+        assert_matches!(actual, Err(PathNotSafe::CannotBeAbsolute));
+    }
+
+    #[test]
+    fn test_parent_not_allowed() {
+        let input = "../../passwords/secret.txt";
+        let actual = SafeFilepath::validate(input);
+        assert_matches!(actual, Err(PathNotSafe::CannotUseParent));
+    }
+
+    #[test]
+    fn test_success() {
+        let input = "main.kcl";
+        let actual = SafeFilepath::validate(input);
+        assert!(actual.is_ok());
+    }
+
+    #[test]
+    fn test_success_nested_file() {
+        let input = "assets/bolt.step";
+        let actual = SafeFilepath::validate(input);
+        assert!(actual.is_ok());
     }
 }

--- a/modeling-cmds/src/websocket.rs
+++ b/modeling-cmds/src/websocket.rs
@@ -110,6 +110,12 @@ pub enum WebSocketRequest {
         /// The authentication header.
         headers: HashMap<String, String>,
     },
+
+    /// Execute a KCL project.
+    ExecKclProject {
+        /// The KCL project to execute.
+        project: crate::exec_kcl::KclProject,
+    },
 }
 
 /// A sequence of modeling requests. If any request fails, following requests will not be tried.
@@ -223,6 +229,12 @@ pub enum OkWebSocketResponseData {
     Debug {
         /// Instance name. This may or may not mean something.
         name: String,
+    },
+
+    /// Result of executing a KCL project.
+    ExecKclProject {
+        /// Result after executing KCL.
+        result: Result<crate::exec_kcl::ExecKclProjectOk, crate::exec_kcl::ExecKclProjectErr>,
     },
 }
 


### PR DESCRIPTION
Adds a new command for executing KCL. Basically it:

- takes a list of files in the KCL project (one of them is the entrypoint, e.g. main.kcl)
- responds with the same type the KCL wasm library does, i.e. a result of Ok or Err, with diagnostic information, artifact graph, etc.
    - To do this, I moved those types (returned by KCL to the frontend) out of kcl-lib and into a new crate. kcl-api
    - kcl-api is imported by both kcl-lib and this project, kcmc.

We should also consider moving this project under the modeling-app monorepo, inside the `rust/` dir as a workspace member. 