### PR TITLE
Release modeling-cmds 0.2.206

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.205"
+version = "0.2.206"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.205"
+version = "0.2.206"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Added

 - Two new params for `sweep`, for translating/rotating profile (#1237)

# Changed

 - `relativeTo` no longer mandatory for `sweep` if one of the new params above is present.