### PR TITLE
Release modeling-cmds 0.2.207

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.206"
+version = "0.2.207"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.206"
+version = "0.2.207"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Added

 - MBD feature edge can now be an ID or a specifier (#1239)