### PR TITLE
Add new RefsSeed to some commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4745,6 +4745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5840,6 +5846,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = { version = "1.0.150", optional = true }
 slog = { version = "2.8.2", optional = true }
 tabled = { version = "0.20", optional = true }
 ts-rs = { version = "12.0.1", optional = true, features = ["chrono-impl", "uuid-impl", "no-serde-warnings", "serde-json-impl"] }
-uuid = { version = "1.23.1", features = ["serde", "v4", "js"] }
+uuid = { version = "1.23.1", features = ["serde", "v4", "v5", "js"] }
 webrtc = { version = "0.12", optional = true }
 
 [dev-dependencies]

--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -4064,19 +4064,12 @@
                 "type": "string",
                 "format": "uuid"
               },
-              "items_expected_at_most": {
-                "nullable": true,
-                "description": "The amount of items we *expect* back at most. Bounds our dynamic UUIDs to some upper limit.",
-                "type": "integer",
-                "format": "uint",
-                "minimum": 0
-              },
               "refs_seed": {
                 "nullable": true,
-                "description": "A client provided seed to generate id references.",
+                "description": "A client provided seed to generate id references. Total references created is bounded by the amount of items we *expect* back at most.",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/RefsSeed"
+                    "$ref": "#/components/schemas/RefsSeedForT"
                   }
                 ]
               },
@@ -7269,15 +7262,6 @@
                 "type": "string",
                 "format": "uuid"
               },
-              "edge_ids": {
-                "nullable": true,
-                "description": "Edges used with `refs_seed` to map to client-controlled UUIDs.",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              },
               "object_id": {
                 "description": "The Solid3d object whose extrusion is being queried.",
                 "type": "string",
@@ -7285,10 +7269,10 @@
               },
               "refs_seed": {
                 "nullable": true,
-                "description": "A client provided seed to generate id references.",
+                "description": "A client provided seed to generate id references. Total references created bounded by the edge ids related to the extruded face.",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/RefsSeed"
+                    "$ref": "#/components/schemas/RefsSeedForT"
                   }
                 ]
               },
@@ -7851,21 +7835,12 @@
               },
               "refs_seed": {
                 "nullable": true,
-                "description": "A client provided seed to generate id references.",
+                "description": "A client provided seed to generate id references. Total references created are bounded by the sketch paths which are related to the region being created.",
                 "allOf": [
                   {
-                    "$ref": "#/components/schemas/RefsSeed"
+                    "$ref": "#/components/schemas/RefsSeedForT"
                   }
                 ]
-              },
-              "sketch_path_ids": {
-                "nullable": true,
-                "description": "Which sketch paths to create a region from. If specified, overrides `object_id`. Primarily used to allow programs to specify what paths to walk and in what order, so they can prepare other calls, in order to fully batch all modeling commands.",
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "format": "uuid"
-                }
               },
               "type": {
                 "type": "string",
@@ -8980,10 +8955,26 @@
           "primitive_index"
         ]
       },
-      "RefsSeed": {
-        "description": "Primarily used so clients can prepare fully batched programs. As modeling commands walk their trees or lists, they will increment a value starting from this seed. The client and server will then have matching references. The client specifying items to walk also specifies order. Check out `CreateRegionFromQueryPoint` for a real example. Conceptual example: Starting from a seed, p1 through p5 are created. client side                 server side l1 -> p1 --modeling call--> l1 -> p1 -> none l2 -> p2 --modeling call--> l2 -> p2 -> none l3 -> p3 --modeling call--> l3 -> p3 -> none l4 -> p4 --modeling call--> l4 -> p4 -> none l5 -> p5 --modeling call--> l5 -> p5 -> none",
-        "type": "string",
-        "format": "uuid"
+      "RefsSeedForT": {
+        "description": "Primarily used so clients can prepare fully batched programs. As modeling commands walk their trees or lists, they will increment a value starting from this seed. The client and server will then have matching references. The client specifying items to walk also specifies order. Check out `CreateRegionFromQueryPoint` for a real example. Conceptual example: Starting from a seed, p1 through p5 are created. client side                 server side l1 -> p1 --modeling call--> p1 -> none l2 -> p2 --modeling call--> p2 -> l2 -> geometry l3 -> p3 --modeling call--> p3 -> none l4 -> p4 --modeling call--> p4 -> none l5 -> p5 --modeling call--> p5 -> l5 -> geometry",
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "The data a modeling command will \"bounds\" to when creating client refs.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "uuid": {
+            "description": "The seed UUID to start generating client refs from.",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "data",
+          "uuid"
+        ]
       },
       "RegionVersion": {
         "description": "Region-creation algorithm version.",

--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -4064,6 +4064,22 @@
                 "type": "string",
                 "format": "uuid"
               },
+              "items_expected_at_most": {
+                "nullable": true,
+                "description": "The amount of items we *expect* back at most. Bounds our dynamic UUIDs to some upper limit.",
+                "type": "integer",
+                "format": "uint",
+                "minimum": 0
+              },
+              "refs_seed": {
+                "nullable": true,
+                "description": "A client provided seed to generate id references.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RefsSeed"
+                  }
+                ]
+              },
               "type": {
                 "type": "string",
                 "enum": [
@@ -7253,10 +7269,28 @@
                 "type": "string",
                 "format": "uuid"
               },
+              "edge_ids": {
+                "nullable": true,
+                "description": "Edges used with `refs_seed` to map to client-controlled UUIDs.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
               "object_id": {
                 "description": "The Solid3d object whose extrusion is being queried.",
                 "type": "string",
                 "format": "uuid"
+              },
+              "refs_seed": {
+                "nullable": true,
+                "description": "A client provided seed to generate id references.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RefsSeed"
+                  }
+                ]
               },
               "type": {
                 "type": "string",
@@ -7814,6 +7848,24 @@
                     "$ref": "#/components/schemas/Point2d"
                   }
                 ]
+              },
+              "refs_seed": {
+                "nullable": true,
+                "description": "A client provided seed to generate id references.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/RefsSeed"
+                  }
+                ]
+              },
+              "sketch_path_ids": {
+                "nullable": true,
+                "description": "Which sketch paths to create a region from. If specified, overrides `object_id`. Primarily used to allow programs to specify what paths to walk and in what order, so they can prepare other calls, in order to fully batch all modeling commands.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                }
               },
               "type": {
                 "type": "string",
@@ -8927,6 +8979,11 @@
           "parent_id",
           "primitive_index"
         ]
+      },
+      "RefsSeed": {
+        "description": "Primarily used so clients can prepare fully batched programs. As modeling commands walk their trees or lists, they will increment a value starting from this seed. The client and server will then have matching references. The client specifying items to walk also specifies order. Check out `CreateRegionFromQueryPoint` for a real example. Conceptual example: Starting from a seed, p1 through p5 are created. client side                 server side l1 -> p1 --modeling call--> l1 -> p1 -> none l2 -> p2 --modeling call--> l2 -> p2 -> none l3 -> p3 --modeling call--> l3 -> p3 -> none l4 -> p4 --modeling call--> l4 -> p4 -> none l5 -> p5 --modeling call--> l5 -> p5 -> none",
+        "type": "string",
+        "format": "uuid"
       },
       "RegionVersion": {
         "description": "Region-creation algorithm version.",

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -41,9 +41,11 @@ define_modeling_cmd_enum! {
                 AnnotationOptions, AnnotationType, CameraDragInteractionType, Color, DistanceType, EntityType,
                 PathComponentConstraintBound, PathComponentConstraintType, PathSegment, PerspectiveCameraParameters,
                 Point2d, Point3d, ExtrudeReference, SceneSelectionType, SceneToolType, SurfaceEdgeReference, Opposite,
+                RefsSeed,
             },
             units,
         };
+        
 
         /// Mike says this usually looks nice.
         fn default_animation_seconds() -> f64 {
@@ -762,6 +764,11 @@ define_modeling_cmd_enum! {
         pub struct EntityGetAllChildUuids {
             /// ID of the entity being queried.
             pub entity_id: Uuid,
+            /// The amount of items we *expect* back at most. Bounds our
+            /// dynamic UUIDs to some upper limit.
+            pub items_expected_at_most: Option<usize>,
+            /// A client provided seed to generate id references.
+            pub refs_seed: Option<RefsSeed>,
         }
 
         /// What are all UUIDs of all the paths sketched on top of this entity?
@@ -2331,6 +2338,10 @@ define_modeling_cmd_enum! {
             pub object_id: Uuid,
             /// Any edge that lies on the extrusion base path.
             pub edge_id: Uuid,
+            /// Edges used with `refs_seed` to map to client-controlled UUIDs.
+            pub edge_ids: Option<Vec<Uuid>>,
+            /// A client provided seed to generate id references.
+            pub refs_seed: Option<RefsSeed>,
         }
 
         /// Get a concise description of all of solids edges.
@@ -2646,6 +2657,12 @@ define_modeling_cmd_enum! {
         pub struct CreateRegionFromQueryPoint {
             /// Which sketch object to create the region from.
             pub object_id: Uuid,
+            /// Which sketch paths to create a region from.
+            /// If specified, overrides `object_id`.
+            /// Primarily used to allow programs to specify what paths to walk
+            /// and in what order, so they can prepare other calls, in order
+            /// to fully batch all modeling commands.
+            pub sketch_path_ids: Option<Vec<Uuid>>,
 
             /// The query point (in the same coordinates as the sketch itself)
             /// if a possible sketch region contains this point, then that region will be created
@@ -2654,6 +2671,8 @@ define_modeling_cmd_enum! {
             #[serde(default, skip_serializing_if = "RegionVersion::is_zero")]
             #[builder(default)]
             pub version: RegionVersion,
+            /// A client provided seed to generate id references.
+            pub refs_seed: Option<RefsSeed>,
         }
 
         /// Finds a suitable point inside the region for calling such that CreateRegionFromQueryPoint will generate an identical region.

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -45,7 +45,7 @@ define_modeling_cmd_enum! {
             },
             units,
         };
-        
+
 
         /// Mike says this usually looks nice.
         fn default_animation_seconds() -> f64 {

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -764,11 +764,10 @@ define_modeling_cmd_enum! {
         pub struct EntityGetAllChildUuids {
             /// ID of the entity being queried.
             pub entity_id: Uuid,
-            /// The amount of items we *expect* back at most. Bounds our
-            /// dynamic UUIDs to some upper limit.
-            pub items_expected_at_most: Option<usize>,
             /// A client provided seed to generate id references.
-            pub refs_seed: Option<RefsSeed>,
+            /// Total references created is bounded by the amount of items we
+            /// *expect* back at most.
+            pub refs_seed: Option<RefsSeed<usize>>,
         }
 
         /// What are all UUIDs of all the paths sketched on top of this entity?
@@ -2338,10 +2337,10 @@ define_modeling_cmd_enum! {
             pub object_id: Uuid,
             /// Any edge that lies on the extrusion base path.
             pub edge_id: Uuid,
-            /// Edges used with `refs_seed` to map to client-controlled UUIDs.
-            pub edge_ids: Option<Vec<Uuid>>,
             /// A client provided seed to generate id references.
-            pub refs_seed: Option<RefsSeed>,
+            /// Total references created bounded by the edge ids related to the
+            /// extruded face.
+            pub refs_seed: Option<RefsSeed<Vec<Uuid>>>,
         }
 
         /// Get a concise description of all of solids edges.
@@ -2657,12 +2656,6 @@ define_modeling_cmd_enum! {
         pub struct CreateRegionFromQueryPoint {
             /// Which sketch object to create the region from.
             pub object_id: Uuid,
-            /// Which sketch paths to create a region from.
-            /// If specified, overrides `object_id`.
-            /// Primarily used to allow programs to specify what paths to walk
-            /// and in what order, so they can prepare other calls, in order
-            /// to fully batch all modeling commands.
-            pub sketch_path_ids: Option<Vec<Uuid>>,
 
             /// The query point (in the same coordinates as the sketch itself)
             /// if a possible sketch region contains this point, then that region will be created
@@ -2671,8 +2664,11 @@ define_modeling_cmd_enum! {
             #[serde(default, skip_serializing_if = "RegionVersion::is_zero")]
             #[builder(default)]
             pub version: RegionVersion,
+
             /// A client provided seed to generate id references.
-            pub refs_seed: Option<RefsSeed>,
+            /// Total references created are bounded by the sketch paths which
+            /// are related to the region being created.
+            pub refs_seed: Option<RefsSeed<Vec<Uuid>>>,
         }
 
         /// Finds a suitable point inside the region for calling such that CreateRegionFromQueryPoint will generate an identical region.

--- a/modeling-cmds/src/id.rs
+++ b/modeling-cmds/src/id.rs
@@ -158,3 +158,12 @@ fn requires_hyphens() {
         ))
     );
 }
+
+/// Namespace all client generated references.
+const NAMESPACE_CLIENT_REFS: uuid::Uuid = uuid::uuid!("b7b9c2f1-1a7b-4e5a-9d7f-3c2d8e6f4a11");
+
+/// Method to generate a dynamic client reference.
+pub fn client_ref_from(obj: (uuid::Uuid, &str)) -> uuid::Uuid {
+  Uuid::new_v5(&NAMESPACE_CLIENT_REFS, format!("{}_{}", obj.0, obj.1).as_bytes())
+}
+

--- a/modeling-cmds/src/id.rs
+++ b/modeling-cmds/src/id.rs
@@ -169,16 +169,16 @@ mod tests {
     #[test]
     fn client_ref_from_idempotent() {
         let a = uuid::Uuid::new_v4();
-        let res = client_ref_from((a, &"hello"));
-        let res2 = client_ref_from((a, &"hello"));
+        let res = client_ref_from((a, "hello"));
+        let res2 = client_ref_from((a, "hello"));
         assert_eq!(res, res2);
     }
 
     #[test]
     fn client_ref_from_different_labels_different_outputs() {
         let a = uuid::Uuid::new_v4();
-        let res = client_ref_from((a, &"hello"));
-        let res2 = client_ref_from((a, &"goodbye"));
+        let res = client_ref_from((a, "hello"));
+        let res2 = client_ref_from((a, "goodbye"));
         assert_ne!(res, res2);
     }
 
@@ -186,8 +186,8 @@ mod tests {
     fn client_ref_from_different_seeds_different_outputs() {
         let a = uuid::Uuid::new_v4();
         let b = uuid::Uuid::new_v4();
-        let res = client_ref_from((a, &"hello"));
-        let res2 = client_ref_from((b, &"hello"));
+        let res = client_ref_from((a, "hello"));
+        let res2 = client_ref_from((b, "hello"));
         assert_ne!(res, res2);
     }
 }

--- a/modeling-cmds/src/id.rs
+++ b/modeling-cmds/src/id.rs
@@ -22,27 +22,6 @@ impl AsRef<Uuid> for ModelingCmdId {
 // implement our own serde deserializer for UUID essentially. We are
 // fortunate to have wrapped the UUID type already so we can do this.
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn modeling_cmd_id_from_bson() {
-        #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
-        struct Id {
-            id: ModelingCmdId,
-        }
-
-        // Serializing and deserializing an ID (via BSON) should not change it.
-        let id_before = Id {
-            id: ModelingCmdId("f09fc20f-40d4-4a73-92fa-05d53baaabac".parse().unwrap()),
-        };
-        let bytes = bson::to_vec(&id_before).unwrap();
-        let id_after = bson::from_reader(bytes.as_slice()).unwrap();
-        assert_eq!(id_before, id_after);
-    }
-}
-
 struct UuidVisitor;
 
 impl<'de> Visitor<'de> for UuidVisitor {
@@ -137,33 +116,78 @@ impl std::fmt::Display for ModelingCmdId {
     }
 }
 
-#[test]
-fn smoke_test() {
-    use std::str::FromStr;
-    assert_eq!(
-        ModelingCmdId::from_str("00000000-0000-0000-0000-000000000000"),
-        Ok(ModelingCmdId(
-            Uuid::from_str("00000000-0000-0000-0000-000000000000").unwrap()
-        ))
-    );
-}
-
-#[test]
-fn requires_hyphens() {
-    use std::str::FromStr;
-    assert_ne!(
-        ModelingCmdId::from_str("00000000000000000000000000000000"),
-        Ok(ModelingCmdId(
-            Uuid::from_str("00000000-0000-0000-0000-000000000000").unwrap()
-        ))
-    );
-}
-
 /// Namespace all client generated references.
 const NAMESPACE_CLIENT_REFS: uuid::Uuid = uuid::uuid!("b7b9c2f1-1a7b-4e5a-9d7f-3c2d8e6f4a11");
 
 /// Method to generate a dynamic client reference.
 pub fn client_ref_from(obj: (uuid::Uuid, &str)) -> uuid::Uuid {
-  Uuid::new_v5(&NAMESPACE_CLIENT_REFS, format!("{}_{}", obj.0, obj.1).as_bytes())
+    Uuid::new_v5(&NAMESPACE_CLIENT_REFS, format!("{}_{}", obj.0, obj.1).as_bytes())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modeling_cmd_id_from_bson() {
+        #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+        struct Id {
+            id: ModelingCmdId,
+        }
+
+        // Serializing and deserializing an ID (via BSON) should not change it.
+        let id_before = Id {
+            id: ModelingCmdId("f09fc20f-40d4-4a73-92fa-05d53baaabac".parse().unwrap()),
+        };
+        let bytes = bson::to_vec(&id_before).unwrap();
+        let id_after = bson::from_reader(bytes.as_slice()).unwrap();
+        assert_eq!(id_before, id_after);
+    }
+
+    #[test]
+    fn smoke_test() {
+        use std::str::FromStr;
+        assert_eq!(
+            ModelingCmdId::from_str("00000000-0000-0000-0000-000000000000"),
+            Ok(ModelingCmdId(
+                Uuid::from_str("00000000-0000-0000-0000-000000000000").unwrap()
+            ))
+        );
+    }
+
+    #[test]
+    fn requires_hyphens() {
+        use std::str::FromStr;
+        assert_ne!(
+            ModelingCmdId::from_str("00000000000000000000000000000000"),
+            Ok(ModelingCmdId(
+                Uuid::from_str("00000000-0000-0000-0000-000000000000").unwrap()
+            ))
+        );
+    }
+
+    #[test]
+    fn client_ref_from_idempotent() {
+        let a = uuid::Uuid::new_v4();
+        let res = client_ref_from((a, &"hello"));
+        let res2 = client_ref_from((a, &"hello"));
+        assert_eq!(res, res2);
+    }
+
+    #[test]
+    fn client_ref_from_different_labels_different_outputs() {
+        let a = uuid::Uuid::new_v4();
+        let res = client_ref_from((a, &"hello"));
+        let res2 = client_ref_from((a, &"goodbye"));
+        assert_ne!(res, res2);
+    }
+
+    #[test]
+    fn client_ref_from_different_seeds_different_outputs() {
+        let a = uuid::Uuid::new_v4();
+        let b = uuid::Uuid::new_v4();
+        let res = client_ref_from((a, &"hello"));
+        let res2 = client_ref_from((b, &"hello"));
+        assert_ne!(res, res2);
+    }
+}

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -1192,7 +1192,7 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// Extrusion face info struct (useful for maintaining mappings between source path segment ids and extrusion faces)
-        #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema, ModelingCmdOutput)]
+        #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema, ModelingCmdOutput, Builder)]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct Solid3dGetExtrusionFaceInfo {
             /// Details of each face.
@@ -1200,7 +1200,8 @@ define_ok_modeling_cmd_response_enum! {
         }
 
         /// Extrusion face info struct (useful for maintaining mappings between source path segment ids and extrusion faces)
-        #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema, ModelingCmdOutput)]
+        // Require's `Builder` so we can construct a mock on the client side (non_exhaustive otherwise prevents us).
+        #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema, ModelingCmdOutput, Builder, Copy)]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct ExtrusionFaceInfo {
             /// Path component (curve) UUID.

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -2210,15 +2210,20 @@ fn one() -> f32 {
 /// Conceptual example:
 /// Starting from a seed, p1 through p5 are created.
 /// client side                 server side
-/// l1 -> p1 --modeling call--> l1 -> p1 -> none
-/// l2 -> p2 --modeling call--> l2 -> p2 -> none
-/// l3 -> p3 --modeling call--> l3 -> p3 -> none
-/// l4 -> p4 --modeling call--> l4 -> p4 -> none
-/// l5 -> p5 --modeling call--> l5 -> p5 -> none
+/// l1 -> p1 --modeling call--> p1 -> none
+/// l2 -> p2 --modeling call--> p2 -> l2 -> geometry
+/// l3 -> p3 --modeling call--> p3 -> none
+/// l4 -> p4 --modeling call--> p4 -> none
+/// l5 -> p5 --modeling call--> p5 -> l5 -> geometry
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Copy)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
 #[serde(rename_all = "snake_case")]
-pub struct RefsSeed(pub Uuid);
+pub struct RefsSeed<T: Sized> {
+    /// The seed UUID to start generating client refs from.
+    pub uuid: Uuid,
+    /// The data a modeling command will "bounds" to when creating client refs.
+    pub data: T,
+}

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -2222,4 +2222,3 @@ fn one() -> f32 {
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
 #[serde(rename_all = "snake_case")]
 pub struct RefsSeed(pub Uuid);
-

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -2201,3 +2201,25 @@ impl From<BodiesUpdated> for BodiesCreated {
 fn one() -> f32 {
     1.0
 }
+
+/// Primarily used so clients can prepare fully batched programs.
+/// As modeling commands walk their trees or lists, they will increment a value
+/// starting from this seed. The client and server will then have matching
+/// references. The client specifying items to walk also specifies order.
+/// Check out `CreateRegionFromQueryPoint` for a real example.
+/// Conceptual example:
+/// Starting from a seed, p1 through p5 are created.
+/// client side                 server side
+/// l1 -> p1 --modeling call--> l1 -> p1 -> none
+/// l2 -> p2 --modeling call--> l2 -> p2 -> none
+/// l3 -> p3 --modeling call--> l3 -> p3 -> none
+/// l4 -> p4 --modeling call--> l4 -> p4 -> none
+/// l5 -> p5 --modeling call--> l5 -> p5 -> none
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Copy)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+#[serde(rename_all = "snake_case")]
+pub struct RefsSeed(pub Uuid);
+

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -2217,10 +2217,11 @@ fn one() -> f32 {
 /// l5 -> p5 --modeling call--> p5 -> l5 -> geometry
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Copy)]
+#[schemars(rename = "RefsSeedForT")]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[serde(rename_all = "snake_case")]
+#[serde(rename = "RefsSeedForT", rename_all = "snake_case")]
 pub struct RefsSeed<T: Sized> {
     /// The seed UUID to start generating client refs from.
     pub uuid: Uuid,


### PR DESCRIPTION
Needed by https://github.com/KittyCAD/engine/pull/4702

I had to move some tests around because they were improperly outside of `mod tests`. Other than that the line additions is mostly from the new `api.json`.