### PR TITLE
Add request_id when executing KCL

### DIFF
--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -10001,6 +10001,11 @@
                   }
                 ]
               },
+              "request_id": {
+                "description": "ID for this request.",
+                "type": "string",
+                "format": "uuid"
+              },
               "type": {
                 "type": "string",
                 "enum": [
@@ -10010,6 +10015,7 @@
             },
             "required": [
               "project",
+              "request_id",
               "type"
             ]
           }

--- a/modeling-cmds/src/websocket.rs
+++ b/modeling-cmds/src/websocket.rs
@@ -113,6 +113,8 @@ pub enum WebSocketRequest {
 
     /// Execute a KCL project.
     ExecKclProject {
+        /// ID for this request.
+        request_id: Uuid,
         /// The KCL project to execute.
         project: crate::exec_kcl::KclProject,
     },


### PR DESCRIPTION
This will help correlate errors with engine logs.