### PR TITLE
Replace SetRenderQuality with Begin/End Execution

### DIFF
--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -8023,26 +8023,37 @@
             ]
           },
           {
-            "description": "Change quality of rendering.",
+            "description": "Tell the engine you're beginning execution, and will be sending many API calls shortly. The engine will render your geometry in reduced detail, to make execution faster. Call EndExecution to restore high quality once you're done sending commands.",
             "type": "object",
             "properties": {
-              "quality": {
-                "description": "What quality of render to use.",
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/RenderQuality"
-                  }
-                ]
+              "enable_render": {
+                "description": "Should rendering occur, or not? If enabled, rendering will be low resolution until you call EndExecution.",
+                "type": "boolean"
               },
               "type": {
                 "type": "string",
                 "enum": [
-                  "set_render_quality"
+                  "begin_execution"
                 ]
               }
             },
             "required": [
-              "quality",
+              "enable_render",
+              "type"
+            ]
+          },
+          {
+            "description": "Tell the engine you're finished execution, and it should resume rendering at high resolution.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "end_execution"
+                ]
+              }
+            },
+            "required": [
               "type"
             ]
           },
@@ -9059,32 +9070,6 @@
             "type": "string",
             "enum": [
               "trajectory_curve"
-            ]
-          }
-        ]
-      },
-      "RenderQuality": {
-        "description": "Rendering quality for the engine.",
-        "oneOf": [
-          {
-            "description": "Full resolution suitable for when the engine is rendering finished geometry.",
-            "type": "string",
-            "enum": [
-              "full"
-            ]
-          },
-          {
-            "description": "Low resolution suitable for use when the engine is actively working on executing and building geometry.",
-            "type": "string",
-            "enum": [
-              "proofing"
-            ]
-          },
-          {
-            "description": "Disable rendering",
-            "type": "string",
-            "enum": [
-              "no_render"
             ]
           }
         ]

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -2722,15 +2722,32 @@ define_modeling_cmd_enum! {
             pub flip: bool,
         }
 
-        /// Change quality of rendering.
+        /// Tell the engine you're beginning execution,
+        /// and will be sending many API calls shortly.
+        /// The engine will render your geometry in
+        /// reduced detail, to make execution faster.
+        /// Call EndExecution to restore high quality
+        /// once you're done sending commands.
         #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, ModelingCmdVariant, Builder)]
         #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
         #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
         #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
-        pub struct SetRenderQuality{
-            /// What quality of render to use.
-            pub quality: crate::shared::RenderQuality,
+        pub struct BeginExecution {
+            /// Should rendering occur, or not?
+            /// If enabled, rendering will be low resolution until you call
+            /// EndExecution.
+            pub enable_render: bool,
+        }
+
+        /// Tell the engine you're finished execution,
+        /// and it should resume rendering at high resolution.
+        #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, ModelingCmdVariant, Builder, Default)]
+        #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+        #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+        #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
+        #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+        pub struct EndExecution {
         }
 
         /// Returns the closest edge to this point.

--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -1395,9 +1395,16 @@ define_ok_modeling_cmd_response_enum! {
         pub struct OffsetSurface {
         }
 
-        /// The response from the 'SetRenderQuality'.
-        #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema, ModelingCmdOutput)]
-        pub struct SetRenderQuality {
+        /// The response from the 'BeginExecution'.
+        #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema, ModelingCmdOutput, Builder, Default)]
+        #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+        pub struct BeginExecution {
+        }
+
+        /// The response from the 'EndExecution'.
+        #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema, ModelingCmdOutput, Builder, Default)]
+        #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
+        pub struct EndExecution {
         }
 
         /// The response from the 'ClosestEdge'.

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -2134,22 +2134,6 @@ pub enum EdgeCutVersion {
     V2,
 }
 
-/// Rendering quality for the engine.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Copy)]
-#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
-#[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
-#[serde(rename_all = "snake_case")]
-pub enum RenderQuality {
-    /// Full resolution suitable for when the engine is rendering finished geometry.
-    Full,
-    /// Low resolution suitable for use when the engine is actively working on executing and building geometry.
-    Proofing,
-    /// Disable rendering
-    NoRender,
-}
-
 const DEFAULT_EDGE_CUT_VERSION: EdgeCutVersion = EdgeCutVersion::V1;
 
 impl EdgeCutVersion {


### PR DESCRIPTION
This matches the engine's conceptual model better. E.g. the engine really wants you to call BeginExecution before EndExecution, but that wasn't clear from the SetRenderQuality calls.