### PR TITLE
Add auto-hole region mappings to region responses

### DIFF
--- a/modeling-cmds/src/ok_response.rs
+++ b/modeling-cmds/src/ok_response.rs
@@ -1321,6 +1321,9 @@ define_ok_modeling_cmd_response_enum! {
         pub struct CreateRegion {
             /// a mapping from the curves within this region to the source component segment curves they were split from
             pub region_mapping: HashMap<Uuid, Uuid>,
+            /// mappings from auto-created hole curves within this region to the source component segment curves they were split from
+            #[serde(default)]
+            pub hole_region_mappings: Vec<HashMap<Uuid, Uuid>>,
         }
 
         /// The response from the 'RegionGetResolvableIntersectionInfo'.
@@ -1347,6 +1350,9 @@ define_ok_modeling_cmd_response_enum! {
         pub struct CreateRegionFromQueryPoint {
             /// a mapping from the curves within this region to the source component segment curves they were split from
             pub region_mapping: HashMap<Uuid, Uuid>,
+            /// mappings from auto-created hole curves within this region to the source component segment curves they were split from
+            #[serde(default)]
+            pub hole_region_mappings: Vec<HashMap<Uuid, Uuid>>,
         }
 
         /// The response from 'RegionGetQueryPoint' modeling command.


### PR DESCRIPTION
Summary

- Adds `hole_region_mappings` to the `CreateRegion` and `CreateRegionFromQueryPoint` modeling command responses.
- Keeps the existing `region_mapping` field unchanged for the outer region loop.

Why

Take the following part

<img width="1280" height="720" alt="rendered_model" src="https://github.com/user-attachments/assets/a0c8e451-23f9-4238-b00e-79226b3ef9fb" />

When this part is made from extruding a single region that has a circle in the middle so is auto cut out, the engine would not return any info back about the mapping from segment to faces for the "cut out" i.e. the circle.

Which means the chamfer on this part is not possible to do with either `getCommonEdge` or the face api.

The hole region mappings in this PR allow for that.

The inner loops grouped as `Vec<HashMap<Uuid, Uuid>>` gives downstream consumers enough topology to rebuild those cutout paths instead of treating all generated cutout segments as one flat bag.

Alternative considered

- We could have changed `region_mapping` itself to something like `Vec<HashMap<Uuid, Uuid>>`, where the first item was the outer loop and the rest were inner loops.
- That would have represented the data, but it would be a breaking change for every consumer that already expects `region_mapping` to be a single map.
- Keeping `region_mapping` for the outer loop and adding `hole_region_mappings` for inner loops is also semantically clearer: there should only be one selected outer boundary, while there can be zero or more generated cutout boundaries.

