### PR TITLE
Remove breaking changes CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,23 +40,6 @@ jobs:
             verbose: true
             files: lcov.info
   
-    check-breaking-changes:
-      name: Check for breaking API changes
-      runs-on: ubuntu-latest-8-cores
-      steps:
-        - uses: actions/checkout@v7
-        - uses: taiki-e/install-action@just
-        - name: Install Rust
-          uses: dtolnay/rust-toolchain@stable
-        - uses: taiki-e/install-action@nextest
-        - name: Setup node
-          uses: actions/setup-node@v6
-        - name: Install openapi-changes
-          run: npm i -g @pb33f/openapi-changes
-        - uses: Swatinem/rust-cache@v2.9.1
-        - name: Run just breaking-api-changes
-          run: just breaking-api-changes
-
     check-lint:
       name: Check lints
       runs-on: ubuntu-latest-8-cores

--- a/justfile
+++ b/justfile
@@ -71,8 +71,3 @@ finish-release pkg:
     git tag kittycad-{{pkg}}-$version -m "kittycad-{{pkg}}-$version"
     git push --tags
     cargo publish -p kittycad-{{pkg}}
-
-# Other actions: changelog, checks, diff, summary
-breaking-api-changes action='summary':
-    just redo-openapi 
-    openapi-changes {{action}} --no-color -b modeling-cmds/openapi/old_api.json modeling-cmds/openapi/api.json

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -7,6 +7,7 @@ description = "Commands in the KittyCAD Modeling API"
 repository = "https://github.com/KittyCAD/modeling-api"
 keywords = ["kittycad"]
 license = "MIT"
+rust-version = "1.96"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
It's always got tons of false positives, it's not useful.

The problem is that adding a new optional field is not a breaking change for clients, and we only care about avoiding breaks for clients. Sure the server has to handle the new field but that's OK, it's our server.