### PR TITLE
Add edge references to mirror operations

### DIFF
--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -2614,6 +2614,32 @@
             "additionalProperties": false
           },
           {
+            "description": "Reflect across an edge identified by its adjacent faces. If used with a 3D mirror, the edge will define the normal of the mirror plane.",
+            "type": "object",
+            "properties": {
+              "edge_reference": {
+                "type": "object",
+                "properties": {
+                  "reference": {
+                    "description": "Stable edge reference.",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/EdgeSpecifier"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "reference"
+                ]
+              }
+            },
+            "required": [
+              "edge_reference"
+            ],
+            "additionalProperties": false
+          },
+          {
             "description": "Reflect across an axis (that goes through a point) If used with a 3D mirror, the axis will define the normal of the mirror plane.",
             "type": "object",
             "properties": {

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -190,7 +190,7 @@ pub enum DirectionType {
 }
 
 /// What to reflect mirrored geometry across
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -201,6 +201,12 @@ pub enum MirrorAcross {
     Edge {
         /// Edge ID.
         id: Uuid,
+    },
+    /// Reflect across an edge identified by its adjacent faces.
+    /// If used with a 3D mirror, the edge will define the normal of the mirror plane.
+    EdgeReference {
+        /// Stable edge reference.
+        reference: EdgeSpecifier,
     },
     /// Reflect across an axis (that goes through a point)
     /// If used with a 3D mirror, the axis will define the normal of the mirror plane.


### PR DESCRIPTION
Allow mirror commands to identify their reflection edge through the stable face API payload instead of requiring a raw edge UUID. Regenerate the modeling commands OpenAPI schema for the new MirrorAcross variant.

Engine branch
https://github.com/KittyCAD/engine/pull/4804