### PR TITLE
Release modeling-cmds 0.2.216

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.215"
+version = "0.2.216"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.215"
+version = "0.2.216"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
Publishes `kittycad-modeling-cmds` version `0.2.216`.