### PR TITLE
Return artifact graph in exec_kcl_project response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,7 +498,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1131,36 +1131,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1178,22 +1154,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -2300,6 +2265,7 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "rayon",
  "serde",
  "serde_core",
 ]
@@ -2483,10 +2449,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "kcl-error"
-version = "0.2.166"
+name = "kcl-api"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65575f7effed7ba8dbc128244db29cf6401122722ac332e9bb3305530d868e"
+checksum = "97a1f74efaa8d3dbffbd48145791b63bd8acbac381704526bd1ca0394f96e5f0"
+dependencies = [
+ "indexmap 2.14.0",
+ "kcl-error",
+ "kittycad-measurements",
+ "kittycad-unit-conversion-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parse-display 0.11.0",
+ "parse-display-derive 0.11.0",
+ "schemars 0.8.22",
+ "serde",
+ "ts-rs",
+ "uuid",
+]
+
+[[package]]
+name = "kcl-error"
+version = "0.2.171"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0473b9dc6790af3bf15cfb40e9957ed96865a6cdd8b2c42ec6eb73336aa019b"
 dependencies = [
  "miette",
  "schemars 0.8.22",
@@ -2562,6 +2546,7 @@ dependencies = [
  "euler",
  "expectorate",
  "http",
+ "kcl-api",
  "kcl-error",
  "kittycad-measurements",
  "kittycad-modeling-cmds-macros",
@@ -4608,6 +4593,8 @@ dependencies = [
  "bytes",
  "chrono",
  "dyn-clone",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -4875,7 +4862,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4903,6 +4890,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -6014,6 +6007,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -19,7 +19,7 @@ tabled = ["dep:tabled"]
 ts-rs = ["dep:ts-rs"]
 slog = ["dep:slog"]
 cxx = ["dep:cxx"]
-websocket = ["dep:serde_json"]
+websocket = ["dep:kcl-api", "dep:serde_json"]
 webrtc = ["dep:webrtc"]
 unstable_exhaustive = []
 python = ["dep:pyo3", "dep:pyo3-stub-gen"]
@@ -36,6 +36,7 @@ enum-iterator = "2.3.0"
 enum-iterator-derive = "1.2.1"
 euler = "0.4.1"
 http = "1.4.0"
+kcl-api = { version = "0.2.171", optional = true }
 kcl-error = { version = "0.2.166" }
 kittycad-modeling-cmds-macros = { workspace = true }
 kittycad-unit-conversion-derive = "0.1.0"

--- a/modeling-cmds/src/exec_kcl.rs
+++ b/modeling-cmds/src/exec_kcl.rs
@@ -66,8 +66,9 @@ impl KclFile {
 #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
 /// Successful KCL project execution response.
 pub struct ExecKclProjectOk {
-    // TODO: Add fields to this as we make KCL data serializable.
-    // Should be a usable subset of `SceneGraphDelta`.
+    /// The artifact graph produced by the KCL execution.
+    #[cfg(feature = "websocket")]
+    pub artifact_graph: serde_json::Value,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
@@ -97,7 +98,10 @@ impl ExecKclProjectErr {
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for ExecKclProjectOk {
     fn arbitrary(_u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self {})
+        Ok(Self {
+            #[cfg(feature = "websocket")]
+            artifact_graph: serde_json::Value::Object(Default::default()),
+        })
     }
 }
 

--- a/modeling-cmds/src/exec_kcl.rs
+++ b/modeling-cmds/src/exec_kcl.rs
@@ -1,4 +1,6 @@
 use bon::Builder;
+#[cfg(feature = "websocket")]
+use kcl_api::ArtifactGraph;
 use kcl_error::{CompilationIssue, KclError};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -68,7 +70,7 @@ impl KclFile {
 pub struct ExecKclProjectOk {
     /// The artifact graph produced by the KCL execution.
     #[cfg(feature = "websocket")]
-    pub artifact_graph: serde_json::Value,
+    pub artifact_graph: ArtifactGraph,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
@@ -100,7 +102,7 @@ impl<'a> arbitrary::Arbitrary<'a> for ExecKclProjectOk {
     fn arbitrary(_u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
             #[cfg(feature = "websocket")]
-            artifact_graph: serde_json::Value::Object(Default::default()),
+            artifact_graph: ArtifactGraph::default(),
         })
     }
 }

--- a/modeling-cmds/src/tests.rs
+++ b/modeling-cmds/src/tests.rs
@@ -7,12 +7,13 @@ async fn test_openapi() {
     let api = example_server().unwrap();
     // Create the API schema.
     let mut definition = api.openapi("Example Modeling API server", "1.2.3".parse().unwrap());
-    let schema = definition
+    let mut schema = definition
         .description("Example modeling API server")
         .contact_url("https://zoo.dev")
         .contact_email("api@zoo.dev")
         .json()
         .unwrap();
+    sort_json_keys(&mut schema);
     let schema_str = serde_json::to_string_pretty(&schema).unwrap();
     expectorate::assert_contents("openapi/api.json", &schema_str);
 
@@ -27,6 +28,27 @@ async fn test_openapi() {
     // Download the old schema, write it to disk.
     let schema = download_openapi_schema("main").await;
     std::fs::write("openapi/old_api.json", schema).unwrap();
+}
+
+fn sort_json_keys(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, value) in map.iter_mut() {
+                sort_json_keys(value);
+                if matches!(key.as_str(), "properties" | "schemas") {
+                    if let serde_json::Value::Object(map) = value {
+                        map.sort_keys();
+                    }
+                }
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for value in values {
+                sort_json_keys(value);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn example_server() -> Result<ApiDescription<()>, String> {


### PR DESCRIPTION
Adds an `artifact_graph` field to `ExecKclProjectOk` so that the artifact graph built during KCL execution is returned to the caller.

