### PR TITLE
Add edge specifier target to extrude-to-reference

### DIFF
--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -2966,10 +2966,20 @@
                 ]
               },
               "target": {
-                "description": "Which sketch to extrude. Must be a closed 2D solid.",
+                "nullable": true,
+                "description": "Which sketch or edge to extrude (legacy API).\n\nMust be a closed 2D solid, or an edge for surface extrusions. Either `target` or `target_reference` must be provided.",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/ModelingCmdId"
+                  }
+                ]
+              },
+              "target_reference": {
+                "nullable": true,
+                "description": "Edge specifier identifying the source edge to extrude. If provided, this takes precedence over `target`.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/EdgeSpecifier"
                   }
                 ]
               },
@@ -2982,7 +2992,6 @@
             },
             "required": [
               "reference",
-              "target",
               "type"
             ]
           },

--- a/modeling-cmds/src/def_enum.rs
+++ b/modeling-cmds/src/def_enum.rs
@@ -186,9 +186,16 @@ define_modeling_cmd_enum! {
         #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
         #[cfg_attr(not(feature = "unstable_exhaustive"), non_exhaustive)]
         pub struct ExtrudeToReference {
-            /// Which sketch to extrude.
-            /// Must be a closed 2D solid.
-            pub target: ModelingCmdId,
+            /// Which sketch or edge to extrude (legacy API).
+            ///
+            /// Must be a closed 2D solid, or an edge for surface extrusions. Either
+            /// `target` or `target_reference` must be provided.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub target: Option<ModelingCmdId>,
+            /// Edge specifier identifying the source edge to extrude. If provided, this
+            /// takes precedence over `target`.
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            pub target_reference: Option<EdgeSpecifier>,
             /// Reference to extrude to.
             /// Extrusion occurs along the target's normal until it is as close to the reference as possible.
             pub reference: ExtrudeReference,


### PR DESCRIPTION
This is a small compatibility fix for edge extrudes using `to`. We already support edge specifier payloads for edge extrude in the length-based path, but the `to` path still required a concrete edge UUID, so this shape could not work: `extrude({ sideFaces = [region001.tags.line1, endCap] }, to = offsetPlane(XY, offset = 10), bodyType = SURFACE, method = NEW)`. We split this into four PRs so the API/KCL/engine compatibility can land safely without blocking PR3 for the broader face API point-and-click work.

## This PR

In `modeling-api`, [KittyCAD/modeling-api#1306](https://github.com/KittyCAD/modeling-api/pull/1306) updates `ExtrudeToReference` so the source can be either the existing legacy `target` UUID or a new `target_reference` edge specifier payload. `target` is now optional, `target_reference` is optional, and callers are expected to provide one of them. The OpenAPI output has been regenerated from the Rust schema.

In the small `modeling-app` compatibility PR, [KittyCAD/modeling-app#12615](https://github.com/KittyCAD/modeling-app/pull/12615) updates `kcl-lib` to compile against that new command shape without changing user-facing KCL behavior. Existing `ExtrudeToReference { target: Some(...) }` artifact handling stays the same, and `target: None` is tolerated as a no-op for artifact graph updates. The old KCL semantic restriction still remains here, so this is intentionally just a bridge PR for dependency ordering.

In `engine`, [KittyCAD/engine#4828](https://github.com/KittyCAD/engine/pull/4828) resolves `target_reference` through the same single-edge face API resolver used by the other edge-specifier endpoints, then passes the resolved edge UUID into the existing extrude-to-reference bridge call. If neither `target` nor `target_reference` is provided, the command now returns a clear request error instead of relying on malformed input.

A second `modeling-app` PR, and this one is user-facing, [KittyCAD/modeling-app#12616](https://github.com/KittyCAD/modeling-app/pull/12616) allows the KCL stdlib to send `target_reference` for edge-specifier source targets when `to` is used, and Z0006 is un-nerfed for `extrude(..., to = ...)`. `twistAngle` is still intentionally left out because that path still needs a concrete twist-extrudable target. This was found working on [PR3 of the face-api work](https://github.com/KittyCAD/modeling-app/pull/10607) but decided to keep it separate from PR3 so the broader face API stack is not held up by this more fringe kwarg combination work.

This PRs need to merge in the order
- Modeling-api PR
- First no-op modeling-app PR
- Engine PR
- Second modeling-app PR

Several of the branches are patched, pointing at each other's branches, which will need to be fixed as they get merged is the above order.