### PR TITLE
Add helix entity references

### DIFF
--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -1574,23 +1574,23 @@
             ]
           },
           {
-            "description": "A uuid referencing a standalone curve in 3D space.",
+            "description": "A uuid referencing a helix.",
             "type": "object",
             "properties": {
-              "curve_id": {
-                "description": "Id of the curve entity.",
+              "helix_id": {
+                "description": "Id of the helix object.",
                 "type": "string",
                 "format": "uuid"
               },
               "type": {
                 "type": "string",
                 "enum": [
-                  "curve3d"
+                  "helix"
                 ]
               }
             },
             "required": [
-              "curve_id",
+              "helix_id",
               "type"
             ]
           },
@@ -1707,8 +1707,7 @@
           "face",
           "plane",
           "vertex",
-          "region",
-          "curve3d"
+          "region"
         ]
       },
       "Error": {

--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -1574,6 +1574,27 @@
             ]
           },
           {
+            "description": "A uuid referencing a standalone curve in 3D space.",
+            "type": "object",
+            "properties": {
+              "curve_id": {
+                "description": "Id of the curve entity.",
+                "type": "string",
+                "format": "uuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "curve3d"
+                ]
+              }
+            },
+            "required": [
+              "curve_id",
+              "type"
+            ]
+          },
+          {
             "description": "A uuid referencing an edge on a solid2d (profile) - used for raw sketch/profile edges. This is distinct from the face-based Edge reference which is used for BRep/swept body edges.",
             "type": "object",
             "properties": {
@@ -1686,7 +1707,8 @@
           "face",
           "plane",
           "vertex",
-          "region"
+          "region",
+          "curve3d"
         ]
       },
       "Error": {

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -127,6 +127,11 @@ pub enum EntityReference {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         topology_fallback: Option<PrimitiveTopologyFallback>,
     },
+    /// A uuid referencing a standalone curve in 3D space.
+    Curve3d {
+        /// Id of the curve entity.
+        curve_id: Uuid,
+    },
     /// A uuid referencing an edge on a solid2d (profile) - used for raw sketch/profile edges.
     /// This is distinct from the face-based Edge reference which is used for BRep/swept body edges.
     Solid2dEdge {
@@ -1205,6 +1210,7 @@ pub enum EntityType {
     Plane,
     Vertex,
     Region,
+    Curve3D,
 }
 
 /// The type of Curve (embedded within path)

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -127,10 +127,10 @@ pub enum EntityReference {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         topology_fallback: Option<PrimitiveTopologyFallback>,
     },
-    /// A uuid referencing a standalone curve in 3D space.
-    Curve3d {
-        /// Id of the curve entity.
-        curve_id: Uuid,
+    /// A uuid referencing a helix.
+    Helix {
+        /// Id of the helix object.
+        helix_id: Uuid,
     },
     /// A uuid referencing an edge on a solid2d (profile) - used for raw sketch/profile edges.
     /// This is distinct from the face-based Edge reference which is used for BRep/swept body edges.
@@ -1210,7 +1210,6 @@ pub enum EntityType {
     Plane,
     Vertex,
     Region,
-    Curve3D,
 }
 
 /// The type of Curve (embedded within path)


### PR DESCRIPTION
We noticed that selecting a standalone helix through the face API returned an empty entity-reference payload, so the app had no stable way to identify or reuse the selected object in point-and-click commands.

This adds a narrow `Helix { helix_id }` entity-reference variant carrying the helix object's existing UUID. We originally modeled this as a generic 3D curve, but that exposed a broader protocol concept than we currently support; keeping the schema helix-specific fixes the concrete gap without making assumptions about future 3D curve entities.

Engine PR: https://github.com/KittyCAD/engine/pull/4882
