### PR TITLE
Make KCL execution optional via feature flag

### DIFF
--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -19,11 +19,12 @@ tabled = ["dep:tabled"]
 ts-rs = ["dep:ts-rs"]
 slog = ["dep:slog"]
 cxx = ["dep:cxx"]
-websocket = ["dep:kcl-api", "dep:serde_json"]
+websocket = ["dep:serde_json"]
 webrtc = ["dep:webrtc"]
 unstable_exhaustive = []
 python = ["dep:pyo3", "dep:pyo3-stub-gen"]
 arbitrary = ["dep:arbitrary", "uuid/arbitrary", "chrono/arbitrary"]
+exec-kcl = ["dep:kcl-api", "dep:kcl-error"]
 
 [dependencies]
 anyhow = "1.0.101"
@@ -37,7 +38,7 @@ enum-iterator-derive = "1.2.1"
 euler = "0.4.1"
 http = "1.4.0"
 kcl-api = { version = "0.2.171", optional = true }
-kcl-error = { version = "0.2.166" }
+kcl-error = { version = "0.2.166", optional = true }
 kittycad-modeling-cmds-macros = { workspace = true }
 kittycad-unit-conversion-derive = "0.1.0"
 # Fork of <crates.io/crates/measurements>

--- a/modeling-cmds/src/lib.rs
+++ b/modeling-cmds/src/lib.rs
@@ -36,6 +36,7 @@ pub mod session;
 pub mod shared;
 
 /// Types for executing KCL and getting response back.
+#[cfg(feature = "exec-kcl")]
 pub mod exec_kcl;
 
 #[cfg(all(test, feature = "derive-jsonschema-on-enums"))]

--- a/modeling-cmds/src/websocket.rs
+++ b/modeling-cmds/src/websocket.rs
@@ -112,6 +112,7 @@ pub enum WebSocketRequest {
     },
 
     /// Execute a KCL project.
+    #[cfg(feature = "exec-kcl")]
     ExecKclProject {
         /// ID for this request.
         request_id: Uuid,
@@ -234,6 +235,7 @@ pub enum OkWebSocketResponseData {
     },
 
     /// Result of executing a KCL project.
+    #[cfg(feature = "exec-kcl")]
     ExecKclProject {
         /// Result after executing KCL.
         result: Result<crate::exec_kcl::ExecKclProjectOk, crate::exec_kcl::ExecKclProjectErr>,


### PR DESCRIPTION
Use `--features exec-kcl` to enable this.

Helpful to avoid unnecessary dependency on kcl-api and kcl-error. Those dependencies are large and add a lot of compile time. Also avoids compiling two copies of kcl-api in kcl-lib (one from the modeling-app/rust/kcl-api, and one from crates.io via kcmc here)