### PR TITLE
Release modeling-cmds 0.2.222

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.221"
+version = "0.2.222"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.221"
+version = "0.2.222"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Changed

 - Make KCL execution optional via feature flag `exec-kcl` (#1322)