### PR TITLE
Release modeling-cmds 0.2.223

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.222"
+version = "0.2.223"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.222"
+version = "0.2.223"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
## Changed

 - Bump pyo3 to 0.29 (#1327)
 - Bump syn from 2 to 3 (#1318)
 - Bump kcl-error and kcl-api to .177 (#1317)