### PR TITLE
Migrate to syn3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,13 +294,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -341,7 +341,7 @@ dependencies = [
  "num-traits 0.2.19",
  "pastey",
  "rayon",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "v_frame",
  "y4m",
 ]
@@ -1296,13 +1296,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1347,7 +1347,7 @@ dependencies = [
  "slog-bunyan",
  "slog-json",
  "slog-term",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls 0.25.0",
  "tokio-util",
@@ -1496,7 +1496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2120,7 +2120,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -2453,7 +2453,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2524,7 +2524,7 @@ dependencies = [
  "indexmap 2.14.0",
  "kcl-error",
  "kittycad-measurements",
- "kittycad-unit-conversion-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kittycad-unit-conversion-derive",
  "parse-display",
  "parse-display-derive",
  "schemars 0.8.22",
@@ -2543,7 +2543,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "ts-rs",
 ]
 
@@ -2580,7 +2580,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -2617,7 +2617,7 @@ dependencies = [
  "kcl-error",
  "kittycad-measurements",
  "kittycad-modeling-cmds-macros",
- "kittycad-unit-conversion-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kittycad-unit-conversion-derive",
  "openapi-lint",
  "openapiv3",
  "parse-display",
@@ -2679,7 +2679,7 @@ dependencies = [
  "lsystem",
  "reqwest",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-tungstenite",
  "uuid",
@@ -2694,18 +2694,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "kittycad-unit-conversion-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7001c46a92c1edce6722a3900539b198230980799035f02d92b4e7df3fc08738"
-dependencies = [
- "inflections",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3864,8 +3852,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.6.4",
- "thiserror 2.0.19",
+ "socket2 0.5.10",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -3887,7 +3875,7 @@ dependencies = [
  "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3902,7 +3890,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4077,7 +4065,7 @@ dependencies = [
  "rand 0.9.5",
  "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -4480,7 +4468,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4506,7 +4494,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki 0.103.14",
  "subtle",
  "zeroize",
 ]
@@ -4555,9 +4543,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5148,7 +5136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5266,17 +5254,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
@@ -5390,7 +5367,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5399,7 +5376,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5431,11 +5408,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -5451,9 +5428,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5863,7 +5840,7 @@ dependencies = [
  "chrono",
  "indexmap 2.14.0",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
  "ts-rs-macros",
  "url",
  "uuid",
@@ -5894,7 +5871,7 @@ dependencies = [
  "log",
  "rand 0.10.2",
  "sha1 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -6548,7 +6525,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ proc-macro2 = "1.0.106"
 quote = "1.0.43"
 syn = "3.0.3"
 
+[patch.crates-io]
+kittycad-unit-conversion-derive = { path = "unit-conversion-derive" }
+
 [profile.bench]
 debug = true
-

--- a/modeling-session/src/lib.rs
+++ b/modeling-session/src/lib.rs
@@ -55,7 +55,7 @@ impl Session {
             await_response_timeout,
             show_grid,
         }: SessionBuilder,
-    ) -> Result<Self, ApiError> {
+    ) -> Result<Self, Box<ApiError>> {
         // TODO: establish WebRTC connections for the user.
         let webrtc = Some(false);
         let (ws, _headers) = client
@@ -94,7 +94,7 @@ impl Session {
         &mut self,
         cmd_id: ModelingCmdId,
         cmd: ModelingCmd,
-    ) -> Result<OkModelingCmdResponse, RunCommandError> {
+    ) -> Result<OkModelingCmdResponse, Box<RunCommandError>> {
         // All messages to the KittyCAD Modeling API will be sent over the WebSocket as Text.
         // The text will contain JSON representing a `ModelingCmdReq`.
         // This takes in a command and its ID, and makes a WebSocket message containing that command.
@@ -102,14 +102,14 @@ impl Session {
         self.actor_tx
             .send(actor::Request::SendModelingCmd(ModelingCmdReq { cmd, cmd_id }, tx))
             .await
-            .map_err(|_| RunCommandError::ActorFailed)?;
-        rx.await.map_err(|_| RunCommandError::ActorFailed)??;
+            .map_err(|_| Box::new(RunCommandError::ActorFailed))?;
+        rx.await.map_err(|_| Box::new(RunCommandError::ActorFailed))??;
         let (tx, rx) = oneshot::channel();
         self.actor_tx
             .send(actor::Request::GetResponse(cmd_id, tx))
             .await
-            .map_err(|_| RunCommandError::ActorFailed)?;
-        let resp = rx.await.map_err(|_| RunCommandError::ActorFailed)??;
+            .map_err(|_| Box::new(RunCommandError::ActorFailed))?;
+        let resp = rx.await.map_err(|_| Box::new(RunCommandError::ActorFailed))??;
         Ok(resp)
     }
 
@@ -118,7 +118,7 @@ impl Session {
         &mut self,
         requests: Vec<ModelingCmdReq>,
         batch_id: ModelingCmdId,
-    ) -> Result<(), RunCommandError> {
+    ) -> Result<(), Box<RunCommandError>> {
         let (tx, rx) = oneshot::channel();
         self.actor_tx
             .send(actor::Request::SendModelingBatch(
@@ -130,8 +130,8 @@ impl Session {
                 tx,
             ))
             .await
-            .map_err(|_| RunCommandError::ActorFailed)?;
-        rx.await.map_err(|_| RunCommandError::ActorFailed)??;
+            .map_err(|_| Box::new(RunCommandError::ActorFailed))?;
+        rx.await.map_err(|_| Box::new(RunCommandError::ActorFailed))??;
         Ok(())
     }
 }

--- a/unit-conversion-derive/Cargo.toml
+++ b/unit-conversion-derive/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 inflections = "1"
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true, features = ["derive", "fold"] }
+syn = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/unit-conversion-derive/src/lib.rs
+++ b/unit-conversion-derive/src/lib.rs
@@ -1,9 +1,8 @@
 //! Derive helpers for implementing unit conversions for enum types.
 
-#[macro_use]
-extern crate quote;
-#[macro_use]
-extern crate syn;
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, Data, DeriveInput};
 
 /// Implement unit conversions based on an enum.
 #[proc_macro_derive(UnitConversion)]
@@ -11,21 +10,21 @@ pub fn derive_unit_conversions(input: proc_macro::TokenStream) -> proc_macro::To
     derive(parse_macro_input!(input)).into()
 }
 
-fn derive(item: syn::DeriveInput) -> proc_macro2::TokenStream {
+fn derive(item: DeriveInput) -> TokenStream {
     let struct_name = &item.ident;
 
     let measurement_struct_name = format_ident!("{}", struct_name.to_string().replace("Unit", ""));
 
     // Make sure this is an enum.
     match &item.data {
-        syn::Data::Enum(_) => {}
+        Data::Enum(_) => {}
         // Return early if this is not an enum.
         _ => return quote!(),
     }
 
     // Get all the variants of the enum.
-    let variants: Vec<&proc_macro2::Ident> = match &item.data {
-        syn::Data::Enum(data) => data.variants.iter().map(|v| &v.ident).collect(),
+    let variants: Vec<&Ident> = match &item.data {
+        Data::Enum(data) => data.variants.iter().map(|v| &v.ident).collect(),
         _ => unreachable!(),
     };
 


### PR DESCRIPTION
we use the Syn crate for writing a proc macro. Syn has released a new version, v3, which we should migrate to.