### PR TITLE
GDT: Make tolerance optional

### DIFF
--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -416,7 +416,7 @@
         "properties": {
           "dimension": {
             "nullable": true,
-            "description": "The explicitly defined dimension.  Only required if the measurement is not automatically calculated.",
+            "description": "The explicitly defined dimension. Only required if the measurement is not automatically calculated.",
             "type": "number",
             "format": "double"
           },
@@ -430,14 +430,12 @@
             ]
           },
           "tolerance": {
+            "nullable": true,
             "description": "The tolerance of the dimension",
             "type": "number",
             "format": "double"
           }
-        },
-        "required": [
-          "tolerance"
-        ]
+        }
       },
       "AnnotationMbdControlFrame": {
         "description": "Parameters for defining an MBD Geometric control frame",
@@ -491,7 +489,7 @@
             "maxLength": 1
           },
           "tolerance": {
-            "description": "Tolerance value - the total tolerance of the geometric control.  The unit is based on the drawing standard.",
+            "description": "Tolerance value - the total tolerance of the geometric control. The unit is based on the drawing standard.",
             "type": "number",
             "format": "double"
           }

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -400,7 +400,8 @@ pub struct AnnotationMbdControlFrame {
     pub symbol: MbdSymbol,
     /// Diameter symbol (if required) whether the geometric control requires a cylindrical or diameter tolerance
     pub diameter_symbol: Option<MbdSymbol>,
-    /// Tolerance value - the total tolerance of the geometric control.  The unit is based on the drawing standard.
+    /// Tolerance value - the total tolerance of the geometric control.
+    /// The unit is based on the drawing standard.
     pub tolerance: f64,
     /// Feature of size or tolerance modifiers
     pub modifier: Option<MbdSymbol>,
@@ -422,10 +423,12 @@ pub struct AnnotationMbdControlFrame {
 pub struct AnnotationMbdBasicDimension {
     /// Type of symbol to use for this dimension (if required)
     pub symbol: Option<MbdSymbol>,
-    /// The explicitly defined dimension.  Only required if the measurement is not automatically calculated.
+    /// The explicitly defined dimension.
+    /// Only required if the measurement is not automatically calculated.
     pub dimension: Option<f64>,
     /// The tolerance of the dimension
-    pub tolerance: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tolerance: Option<f64>,
 }
 
 /// Parameters for defining an MBD Basic Dimension Annotation state which is measured between two positions in 3D


### PR DESCRIPTION
The distance/dimension gdt function should not have a hard requirement for a tolerance arg. This is what GD&T is for- to describe the required accuracy of a feature without having to add a tolerance to every dimension.

If tolerance is not sent, no tolerance should be shown. In other words, the leader in the scene should show only the dimension value.