### PR TITLE
Apply documented defaults to format options

### DIFF
--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -2253,6 +2253,16 @@
             "properties": {
               "coords": {
                 "description": "Co-ordinate system of input data.\n\nDefaults to the [KittyCAD co-ordinate system].\n\n[KittyCAD co-ordinate system]: ../coord/constant.KITTYCAD.html",
+                "default": {
+                  "forward": {
+                    "axis": "y",
+                    "direction": "negative"
+                  },
+                  "up": {
+                    "axis": "z",
+                    "direction": "positive"
+                  }
+                },
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/System"
@@ -2267,6 +2277,7 @@
               },
               "units": {
                 "description": "The units of the input data.\n\nThis is very important for correct scaling and when calculating physics properties like mass, etc.\n\nDefaults to millimeters.",
+                "default": "mm",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/UnitLength"
@@ -2275,9 +2286,7 @@
               }
             },
             "required": [
-              "coords",
-              "type",
-              "units"
+              "type"
             ]
           },
           {
@@ -2324,6 +2333,16 @@
             "properties": {
               "coords": {
                 "description": "Co-ordinate system of input data.\n\nDefaults to the [KittyCAD co-ordinate system].\n\n[KittyCAD co-ordinate system]: ../coord/constant.KITTYCAD.html",
+                "default": {
+                  "forward": {
+                    "axis": "y",
+                    "direction": "negative"
+                  },
+                  "up": {
+                    "axis": "z",
+                    "direction": "positive"
+                  }
+                },
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/System"
@@ -2338,6 +2357,7 @@
               },
               "units": {
                 "description": "The units of the input data.\n\nThis is very important for correct scaling and when calculating physics properties like mass, etc.\n\nDefaults to millimeters.",
+                "default": "mm",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/UnitLength"
@@ -2346,9 +2366,7 @@
               }
             },
             "required": [
-              "coords",
-              "type",
-              "units"
+              "type"
             ]
           },
           {
@@ -2442,6 +2460,16 @@
             "properties": {
               "coords": {
                 "description": "Co-ordinate system of input data.\n\nDefaults to the [KittyCAD co-ordinate system].\n\n[KittyCAD co-ordinate system]: ../coord/constant.KITTYCAD.html",
+                "default": {
+                  "forward": {
+                    "axis": "y",
+                    "direction": "negative"
+                  },
+                  "up": {
+                    "axis": "z",
+                    "direction": "positive"
+                  }
+                },
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/System"
@@ -2456,6 +2484,7 @@
               },
               "units": {
                 "description": "The units of the input data.\n\nThis is very important for correct scaling and when calculating physics properties like mass, etc.\n\nDefaults to millimeters.",
+                "default": "mm",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/UnitLength"
@@ -2464,9 +2493,7 @@
               }
             },
             "required": [
-              "coords",
-              "type",
-              "units"
+              "type"
             ]
           }
         ]
@@ -8352,6 +8379,7 @@
             "properties": {
               "presentation": {
                 "description": "Specifies how the JSON will be presented.",
+                "default": "pretty",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GltfPresentation"
@@ -8360,6 +8388,7 @@
               },
               "storage": {
                 "description": "Specifies which kind of glTF 2.0 will be exported.",
+                "default": "embedded",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/GltfStorage"
@@ -8374,8 +8403,6 @@
               }
             },
             "required": [
-              "presentation",
-              "storage",
               "type"
             ]
           },
@@ -8385,6 +8412,16 @@
             "properties": {
               "coords": {
                 "description": "Co-ordinate system of output data.\n\nDefaults to the [KittyCAD co-ordinate system].\n\n[KittyCAD co-ordinate system]: ../coord/constant.KITTYCAD.html",
+                "default": {
+                  "forward": {
+                    "axis": "y",
+                    "direction": "negative"
+                  },
+                  "up": {
+                    "axis": "z",
+                    "direction": "positive"
+                  }
+                },
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/System"
@@ -8399,6 +8436,7 @@
               },
               "units": {
                 "description": "Export length unit.\n\nDefaults to millimeters.",
+                "default": "mm",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/UnitLength"
@@ -8407,9 +8445,7 @@
               }
             },
             "required": [
-              "coords",
-              "type",
-              "units"
+              "type"
             ]
           },
           {
@@ -8418,6 +8454,16 @@
             "properties": {
               "coords": {
                 "description": "Co-ordinate system of output data.\n\nDefaults to the [KittyCAD co-ordinate system].\n\n[KittyCAD co-ordinate system]: ../coord/constant.KITTYCAD.html",
+                "default": {
+                  "forward": {
+                    "axis": "y",
+                    "direction": "negative"
+                  },
+                  "up": {
+                    "axis": "z",
+                    "direction": "positive"
+                  }
+                },
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/System"
@@ -8426,6 +8472,9 @@
               },
               "selection": {
                 "description": "Export selection.",
+                "default": {
+                  "type": "default_scene"
+                },
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/Selection"
@@ -8434,6 +8483,7 @@
               },
               "storage": {
                 "description": "The storage for the output PLY file.",
+                "default": "ascii",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/PlyStorage"
@@ -8448,6 +8498,7 @@
               },
               "units": {
                 "description": "Export length unit.\n\nDefaults to millimeters.",
+                "default": "mm",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/UnitLength"
@@ -8456,11 +8507,7 @@
               }
             },
             "required": [
-              "coords",
-              "selection",
-              "storage",
-              "type",
-              "units"
+              "type"
             ]
           },
           {
@@ -8527,6 +8574,16 @@
             "properties": {
               "coords": {
                 "description": "Co-ordinate system of output data.\n\nDefaults to the [KittyCAD co-ordinate system].\n\n[KittyCAD co-ordinate system]: ../coord/constant.KITTYCAD.html",
+                "default": {
+                  "forward": {
+                    "axis": "y",
+                    "direction": "negative"
+                  },
+                  "up": {
+                    "axis": "z",
+                    "direction": "positive"
+                  }
+                },
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/System"
@@ -8535,6 +8592,9 @@
               },
               "selection": {
                 "description": "Export selection.",
+                "default": {
+                  "type": "default_scene"
+                },
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/Selection"
@@ -8543,6 +8603,7 @@
               },
               "storage": {
                 "description": "Export storage.",
+                "default": "binary",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/StlStorage"
@@ -8557,6 +8618,7 @@
               },
               "units": {
                 "description": "Export length unit.\n\nDefaults to millimeters.",
+                "default": "mm",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/UnitLength"
@@ -8565,11 +8627,7 @@
               }
             },
             "required": [
-              "coords",
-              "selection",
-              "storage",
-              "type",
-              "units"
+              "type"
             ]
           }
         ]

--- a/modeling-cmds/src/format/gltf.rs
+++ b/modeling-cmds/src/format/gltf.rs
@@ -38,7 +38,7 @@ pub mod export {
     use super::*;
     /// Options for exporting glTF 2.0.
     #[derive(Default, Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
-    #[serde(rename = "GltfExportOptions")]
+    #[serde(default, rename = "GltfExportOptions")]
     #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     #[cfg_attr(

--- a/modeling-cmds/src/format/mod.rs
+++ b/modeling-cmds/src/format/mod.rs
@@ -443,3 +443,18 @@ proprietary_brep_formats! {
     (parasolid, "ParasolidImportOptions", "Parasolid part format", coord::KITTYCAD)
     (sldprt, "SldprtImportOptions", "SolidWorks part format", coord::OPENGL)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{InputFormat3d, OutputFormat3d};
+
+    #[test]
+    fn documented_format_defaults_are_applied_when_omitted() {
+        for format in ["obj", "ply", "stl"] {
+            let json = format!(r#"{{"type":"{format}"}}"#);
+            serde_json::from_str::<InputFormat3d>(&json).unwrap();
+            serde_json::from_str::<OutputFormat3d>(&json).unwrap();
+        }
+        serde_json::from_str::<OutputFormat3d>(r#"{"type":"gltf"}"#).unwrap();
+    }
+}

--- a/modeling-cmds/src/format/obj.rs
+++ b/modeling-cmds/src/format/obj.rs
@@ -10,7 +10,7 @@ pub mod import {
 
     /// Options for importing OBJ.
     #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
-    #[serde(rename = "ObjImportOptions")]
+    #[serde(default, rename = "ObjImportOptions")]
     #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
@@ -66,7 +66,7 @@ pub mod export {
 
     /// Options for exporting OBJ.
     #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
-    #[serde(rename = "ObjExportOptions")]
+    #[serde(default, rename = "ObjExportOptions")]
     #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     #[cfg_attr(

--- a/modeling-cmds/src/format/ply.rs
+++ b/modeling-cmds/src/format/ply.rs
@@ -11,7 +11,7 @@ pub mod import {
 
     /// Options for importing PLY.
     #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
-    #[serde(rename = "PlyImportOptions")]
+    #[serde(default, rename = "PlyImportOptions")]
     #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
@@ -68,7 +68,7 @@ pub mod export {
 
     /// Options for exporting PLY.
     #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
-    #[serde(rename = "PlyExportOptions")]
+    #[serde(default, rename = "PlyExportOptions")]
     #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     #[cfg_attr(

--- a/modeling-cmds/src/format/stl.rs
+++ b/modeling-cmds/src/format/stl.rs
@@ -11,7 +11,7 @@ pub mod import {
 
     /// Options for importing STL.
     #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
-    #[serde(rename = "StlImportOptions")]
+    #[serde(default, rename = "StlImportOptions")]
     #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     #[cfg_attr(feature = "ts-rs", ts(export_to = "ModelingCmd.ts"))]
@@ -67,7 +67,7 @@ pub mod export {
 
     /// Options for exporting STL.
     #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Builder)]
-    #[serde(rename = "StlExportOptions")]
+    #[serde(default, rename = "StlExportOptions")]
     #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     #[cfg_attr(


### PR DESCRIPTION
Apply the documented defaults when OBJ, PLY, STL, and glTF option fields are omitted. The generated OpenAPI schema no longer marks those fields as required.

Closes #1300.