### PR TITLE
Add KCL version

### DIFF
--- a/modeling-cmds/src/kcl_version.rs
+++ b/modeling-cmds/src/kcl_version.rs
@@ -1,0 +1,76 @@
+use std::str::FromStr;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Which KCL versions does Zoo support?
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, PartialEq, Eq, Ord, PartialOrd, schemars::JsonSchema)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export))]
+pub enum KclVersion {
+    /// Original KCL released in 2025
+    #[default]
+    #[serde(rename = "1.0")]
+    V1,
+    /// KCL v2 is the same as KCL v1, except
+    /// that it supports the `region` function.
+    #[serde(rename = "2.0")]
+    V2,
+    /// KCL v3 is currently in development.
+    #[serde(rename = "3.0-preview")]
+    V3Preview,
+    // When you add a new version, please add it to the error string in KclVersionError's
+    // Display and FromStr impls.
+}
+
+impl KclVersion {
+    /// Get the canonical string representation for each version.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::V1 => "1.0",
+            Self::V2 => "2.0",
+            Self::V3Preview => "3.0-preview",
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct KclVersionError;
+
+impl core::error::Error for KclVersionError {}
+
+impl std::fmt::Display for KclVersionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Unrecognized version. Valid versions are 1.0, 2.0 and (experimentally) 3.0-preview"
+        )
+    }
+}
+
+impl FromStr for KclVersion {
+    type Err = KclVersionError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "1" | "1.0" | "1.0.0" => Ok(Self::V1),
+            "2" | "2.0" | "2.0.0" => Ok(Self::V2),
+            "3-preview" | "3.0-preview" | "3.0.0-preview" => Ok(Self::V3Preview),
+            _other => Err(KclVersionError),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_str() {
+        for input in [KclVersion::V1, KclVersion::V2, KclVersion::V3Preview] {
+            let serialized = input.as_str();
+            let deserialized: KclVersion = serialized.parse().unwrap();
+            assert_eq!(input, deserialized);
+        }
+    }
+}

--- a/modeling-cmds/src/kcl_version.rs
+++ b/modeling-cmds/src/kcl_version.rs
@@ -34,12 +34,13 @@ impl KclVersion {
     }
 }
 
+/// Error returned when user tries to use an invalid KCL version.
 #[derive(Debug)]
-pub struct KclVersionError;
+pub struct InvalidKclVersion;
 
-impl core::error::Error for KclVersionError {}
+impl core::error::Error for InvalidKclVersion {}
 
-impl std::fmt::Display for KclVersionError {
+impl std::fmt::Display for InvalidKclVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -49,14 +50,14 @@ impl std::fmt::Display for KclVersionError {
 }
 
 impl FromStr for KclVersion {
-    type Err = KclVersionError;
+    type Err = InvalidKclVersion;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
             "1" | "1.0" | "1.0.0" => Ok(Self::V1),
             "2" | "2.0" | "2.0.0" => Ok(Self::V2),
             "3-preview" | "3.0-preview" | "3.0.0-preview" => Ok(Self::V3Preview),
-            _other => Err(KclVersionError),
+            _other => Err(InvalidKclVersion),
         }
     }
 }

--- a/modeling-cmds/src/lib.rs
+++ b/modeling-cmds/src/lib.rs
@@ -52,7 +52,11 @@ pub mod units;
 #[cfg(feature = "websocket")]
 pub mod websocket;
 
+/// Defines which KCL versions exist, and how to represent them.
+mod kcl_version;
+
 // Export some key items for anyone consuming the library.
 pub use def_enum::*;
+pub use kcl_version::KclVersion;
 pub use ok_response::output;
 pub use traits::*;

--- a/modeling-cmds/src/lib.rs
+++ b/modeling-cmds/src/lib.rs
@@ -57,6 +57,6 @@ mod kcl_version;
 
 // Export some key items for anyone consuming the library.
 pub use def_enum::*;
-pub use kcl_version::KclVersion;
+pub use kcl_version::{InvalidKclVersion, KclVersion};
 pub use ok_response::output;
 pub use traits::*;

--- a/modeling-cmds/src/session.rs
+++ b/modeling-cmds/src/session.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::shared::PostEffectType;
+use crate::{shared::PostEffectType, KclVersion};
 
 /// Params for starting the engine.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -35,6 +35,10 @@ pub struct EngineParams {
     /// This slows down rendering, so it's off by default.
     #[serde(default)]
     pub order_independent_transparency: bool,
+    /// Which KCL+Engine version should the engine use?
+    /// Clients use this to opt into updated algorithms and behaviours.
+    #[serde(default)]
+    pub kcl_version: KclVersion,
 }
 
 impl Default for EngineParams {
@@ -51,6 +55,7 @@ impl Default for EngineParams {
             replay: None,
             api_call_id: None,
             order_independent_transparency: false,
+            kcl_version: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Sent when initializing engine.

Moves KclVersion out of the kcl-lib, as it's really a shared version between KCL and the engine. Paired with https://github.com/KittyCAD/modeling-app/pull/13577.

---

Contributes to https://github.com/KittyCAD/roadmap/issues/609