### PR TITLE
Add optional 'name' field to GD&T annotations

### DIFF
--- a/modeling-cmds/openapi/api.json
+++ b/modeling-cmds/openapi/api.json
@@ -556,6 +556,11 @@
             "type": "number",
             "format": "float"
           },
+          "name": {
+            "nullable": true,
+            "description": "Human-friendly identifier for this annotation. Included in some exports and metadata of the model. This is _not_ displayed visually in, the annotation, it's only metadata.",
+            "type": "string"
+          },
           "position": {
             "nullable": true,
             "description": "Position to put the annotation",

--- a/modeling-cmds/src/shared.rs
+++ b/modeling-cmds/src/shared.rs
@@ -354,6 +354,12 @@ pub struct AnnotationOptions {
     pub feature_control: Option<AnnotationFeatureControl>,
     /// Set as a feature tag annotation
     pub feature_tag: Option<AnnotationFeatureTag>,
+    /// Human-friendly identifier for this annotation.
+    /// Included in some exports and metadata of the model.
+    /// This is _not_ displayed visually in, the annotation,
+    /// it's only metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
 /// Options for annotation text


### PR DESCRIPTION
KCL already has an identifier for each GD&T annotation: the variable name. Clients like KCL can set this field and the Zoo engine will try to include it in metadata (e.g. in exported STEP files).