### PR TITLE
Add convenience method to VirtualFile

### DIFF
--- a/modeling-cmds/src/format/mod.rs
+++ b/modeling-cmds/src/format/mod.rs
@@ -179,6 +179,11 @@ pub struct VirtualFile {
 }
 
 impl VirtualFile {
+    /// Create a new virtual file.
+    pub fn new(path: std::path::PathBuf, data: Vec<u8>) -> Self {
+        Self { path, data }
+    }
+
     /// Returns true if the file name has the given extension.
     pub fn has_extension(&self, required_extension: &str) -> bool {
         self.path


### PR DESCRIPTION
It's easier to do
`VirtualFile::new(path, data)`
than
`VirtualFile::builder().path(path).data(data).build()`