### PR TITLE
Release modeling-cmds 0.2.227

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.226"
+version = "0.2.227"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.226"
+version = "0.2.227"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Changed

 - `tolerance` field of GD&T distance annotations is now optional (#1349)