### PR TITLE
UoM can be parsed by Clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2605,6 +2605,7 @@ dependencies = [
  "bon",
  "bson",
  "chrono",
+ "clap",
  "cxx",
  "data-encoding",
  "dropshot",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.96"
 all-features = true
 
 [features]
+clap = ["dep:clap"]
 default = []
 derive-jsonschema-on-enums = []
 tabled = ["dep:tabled"]
@@ -31,6 +32,7 @@ anyhow = "1.0.101"
 arbitrary = { version = "1", features = ["derive"], optional = true }
 bon = "3.9.1"
 chrono = { version = "0.4.43", features = ["serde"] }
+clap = { version = "4.6.6", optional = true, default-features = false, features = ["derive"] }
 cxx = { version = "1.0", optional = true }
 data-encoding = "2.11.0"
 enum-iterator = "2.3.0"

--- a/modeling-cmds/src/units.rs
+++ b/modeling-cmds/src/units.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "clap")]
+use clap::ValueEnum;
 use kittycad_unit_conversion_derive::UnitConversion;
 use parse_display_derive::{Display, FromStr};
 use schemars::JsonSchema;
@@ -24,6 +26,7 @@ use crate::impl_extern_type;
     UnitConversion,
     Hash,
 )]
+#[cfg_attr(feature = "clap", derive(ValueEnum))]
 #[cfg_attr(feature = "tabled", derive(tabled::Tabled))]
 #[display(style = "snake_case")]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
@@ -100,6 +103,7 @@ impl_extern_type! {
     UnitConversion,
     Hash,
 )]
+#[cfg_attr(feature = "clap", derive(ValueEnum))]
 #[cfg_attr(feature = "tabled", derive(tabled::Tabled))]
 #[serde(rename_all = "snake_case")]
 #[display(style = "snake_case")]
@@ -139,6 +143,7 @@ pub enum UnitAngle {
     Default,
     Hash,
 )]
+#[cfg_attr(feature = "clap", derive(ValueEnum))]
 #[cfg_attr(feature = "tabled", derive(tabled::Tabled))]
 #[serde(rename_all = "snake_case")]
 #[display(style = "snake_case")]
@@ -219,6 +224,7 @@ impl UnitArea {
     UnitConversion,
     Hash,
 )]
+#[cfg_attr(feature = "clap", derive(ValueEnum))]
 #[cfg_attr(feature = "tabled", derive(tabled::Tabled))]
 #[display(style = "snake_case")]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
@@ -282,6 +288,7 @@ impl UnitDensity {
     UnitConversion,
     Hash,
 )]
+#[cfg_attr(feature = "clap", derive(ValueEnum))]
 #[cfg_attr(feature = "tabled", derive(tabled::Tabled))]
 #[serde(rename_all = "snake_case")]
 #[display(style = "snake_case")]


### PR DESCRIPTION
Allow units-of-measure types (e.g. volume, length) to be used by `clap` for deserializing command line args from strings into those enums.

This derive is gated behind a feature flag `clap` so that other consumers that aren't CLIs don't have to pull it in.