### PR TITLE
Release modeling-cmds 0.2.229

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "kittycad-modeling-cmds"
-version = "0.2.228"
+version = "0.2.229"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/modeling-cmds/Cargo.toml
+++ b/modeling-cmds/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittycad-modeling-cmds"
-version = "0.2.228"
+version = "0.2.229"
 edition = "2021"
 authors = ["KittyCAD, Inc."]
 description = "Commands in the KittyCAD Modeling API"


### PR DESCRIPTION
# Added
* UoM enums can be parsed by Clap (#1369)

# Changed
* Tweak base64 format (serialize Base64Data as standard base64) (#1352)